### PR TITLE
feat: restrict bot commands to specific user ID

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ API_BASE_URL=http://localhost:3000
 API_KEY=your-api-key-here
 DASHBOARD_URL=http://localhost:5173
 
+# User Access Restriction (Optional)
+# If set, only this Discord user ID can use bot commands
+# Leave commented out or empty to allow all users
+# ALLOWED_USER_ID=your-discord-user-id-here
+
 # New Relic Logs API Configuration
 NEW_RELIC_LICENSE_KEY=your-license-key-here
 NEW_RELIC_ENABLED=true

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -9,6 +9,9 @@ const envSchema = z.object({
   API_BASE_URL: z.string().url('API_BASE_URL must be a valid URL'),
   API_KEY: z.string().min(1, 'API_KEY is required'),
   DASHBOARD_URL: z.string().url('DASHBOARD_URL must be a valid URL').optional(),
+  ALLOWED_USER_ID: z.string()
+    .regex(/^\d{17,19}$/, 'ALLOWED_USER_ID must be a valid Discord snowflake (17-19 digits)')
+    .optional(),
 });
 
 export type EnvironmentConfig = z.infer<typeof envSchema>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,9 @@ const permissionLogger = container.get<PermissionLoggerService>(TYPES.Permission
 // Get cooldown service from container
 const cooldownService = container.get<CooldownService>(TYPES.CooldownService);
 
+// Get config service from container
+const configService = container.get<ConfigService>(TYPES.ConfigService);
+
 // Register commands
 commandRegistry.register(configCommand);
 commandRegistry.register(helpCommand);
@@ -100,7 +103,7 @@ client.on('guildMemberRemove', createGuildMemberRemoveEvent(memberService).execu
 client.on('guildMemberUpdate', createGuildMemberUpdateEvent(memberService).execute);
 
 // Register interaction handler with permission services
-client.on('interactionCreate', createInteractionCreateEvent(commandRegistry, permissionValidator, permissionLogger, apiService, cooldownService).execute);
+client.on('interactionCreate', createInteractionCreateEvent(commandRegistry, permissionValidator, permissionLogger, apiService, cooldownService, configService).execute);
 
 // Bot ready event - use 'clientReady' for Discord.js v14
 client.once('ready', async () => {
@@ -146,5 +149,4 @@ client.once('ready', async () => {
 });
 
 // Login to Discord
-const configService = container.get<ConfigService>(TYPES.ConfigService);
 client.login(configService.discordToken);

--- a/src/services/config.service.ts
+++ b/src/services/config.service.ts
@@ -30,5 +30,9 @@ export class ConfigService {
   get dashboardUrl(): string | undefined {
     return this.config.DASHBOARD_URL;
   }
+
+  get allowedUserId(): string | undefined {
+    return this.config.ALLOWED_USER_ID;
+  }
 }
 

--- a/test/config/environment.test.ts
+++ b/test/config/environment.test.ts
@@ -48,5 +48,78 @@ describe('Environment Configuration', () => {
 
     expect(() => loadEnvironmentConfig()).toThrow();
   });
+
+  it('should load valid ALLOWED_USER_ID', () => {
+    process.env = {
+      DISCORD_TOKEN: 'test-token',
+      API_BASE_URL: 'http://localhost:3000',
+      API_KEY: 'test-key',
+      ALLOWED_USER_ID: '354474826192388127',
+    };
+
+    const config = loadEnvironmentConfig();
+
+    expect(config.ALLOWED_USER_ID).toBe('354474826192388127');
+  });
+
+  it('should allow ALLOWED_USER_ID to be undefined when not set', () => {
+    process.env = {
+      DISCORD_TOKEN: 'test-token',
+      API_BASE_URL: 'http://localhost:3000',
+      API_KEY: 'test-key',
+    };
+
+    const config = loadEnvironmentConfig();
+
+    expect(config.ALLOWED_USER_ID).toBeUndefined();
+  });
+
+  it('should throw error on invalid ALLOWED_USER_ID format (too short)', () => {
+    process.env = {
+      DISCORD_TOKEN: 'test-token',
+      API_BASE_URL: 'http://localhost:3000',
+      API_KEY: 'test-key',
+      ALLOWED_USER_ID: '1234567890123456', // 16 digits
+    };
+
+    expect(() => loadEnvironmentConfig()).toThrow();
+  });
+
+  it('should throw error on invalid ALLOWED_USER_ID format (non-numeric)', () => {
+    process.env = {
+      DISCORD_TOKEN: 'test-token',
+      API_BASE_URL: 'http://localhost:3000',
+      API_KEY: 'test-key',
+      ALLOWED_USER_ID: 'abc123456789012345',
+    };
+
+    expect(() => loadEnvironmentConfig()).toThrow();
+  });
+
+  it('should accept valid Discord snowflake (17 digits)', () => {
+    process.env = {
+      DISCORD_TOKEN: 'test-token',
+      API_BASE_URL: 'http://localhost:3000',
+      API_KEY: 'test-key',
+      ALLOWED_USER_ID: '12345678901234567', // 17 digits
+    };
+
+    const config = loadEnvironmentConfig();
+
+    expect(config.ALLOWED_USER_ID).toBe('12345678901234567');
+  });
+
+  it('should accept valid Discord snowflake (19 digits)', () => {
+    process.env = {
+      DISCORD_TOKEN: 'test-token',
+      API_BASE_URL: 'http://localhost:3000',
+      API_KEY: 'test-key',
+      ALLOWED_USER_ID: '1234567890123456789', // 19 digits
+    };
+
+    const config = loadEnvironmentConfig();
+
+    expect(config.ALLOWED_USER_ID).toBe('1234567890123456789');
+  });
 });
 

--- a/test/events/interactionCreate.test.ts
+++ b/test/events/interactionCreate.test.ts
@@ -1,0 +1,260 @@
+import { createInteractionCreateEvent } from '../../src/events/interactionCreate';
+import { CommandRegistryService } from '../../src/commands/command-registry.service';
+import { PermissionValidatorService } from '../../src/services/permission-validator.service';
+import { PermissionLoggerService } from '../../src/services/permission-logger.service';
+import { ApiService } from '../../src/services/api.service';
+import { CooldownService } from '../../src/services/cooldown.service';
+import { ConfigService } from '../../src/services/config.service';
+import { ICommand } from '../../src/commands/command.interface';
+import { ChatInputCommandInteraction, Events } from 'discord.js';
+import { logger } from '../../src/utils/logger';
+
+// Mock logger
+jest.mock('../../src/utils/logger', () => ({
+  logger: {
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+describe('InteractionCreate Event Handler', () => {
+  let mockCommandRegistry: jest.Mocked<CommandRegistryService>;
+  let mockPermissionValidator: jest.Mocked<PermissionValidatorService>;
+  let mockPermissionLogger: jest.Mocked<PermissionLoggerService>;
+  let mockApiService: jest.Mocked<ApiService>;
+  let mockCooldownService: jest.Mocked<CooldownService>;
+  let mockConfigService: jest.Mocked<ConfigService>;
+  let mockCommand: jest.Mocked<ICommand>;
+  let mockInteraction: jest.Mocked<ChatInputCommandInteraction>;
+
+  beforeEach(() => {
+    // Create mocks
+    mockCommandRegistry = {
+      get: jest.fn(),
+    } as unknown as jest.Mocked<CommandRegistryService>;
+
+    mockPermissionValidator = {
+      validateCommandPermissions: jest.fn().mockReturnValue({ allowed: true }),
+    } as unknown as jest.Mocked<PermissionValidatorService>;
+
+    mockPermissionLogger = {
+      logCommandExecution: jest.fn(),
+      logPermissionDenial: jest.fn(),
+      logPermissionGrant: jest.fn(),
+    } as unknown as jest.Mocked<PermissionLoggerService>;
+
+    mockApiService = {
+      getGuildSettings: jest.fn().mockResolvedValue({}),
+    } as unknown as jest.Mocked<ApiService>;
+
+    mockCooldownService = {
+      checkCooldown: jest.fn().mockReturnValue(0),
+      setCooldown: jest.fn(),
+    } as unknown as jest.Mocked<CooldownService>;
+
+    mockConfigService = {
+      allowedUserId: undefined,
+    } as unknown as jest.Mocked<ConfigService>;
+
+    mockCommand = {
+      data: {
+        name: 'test-command',
+        description: 'Test command',
+      },
+      execute: jest.fn().mockResolvedValue(undefined),
+      metadata: {
+        category: 'public' as const,
+        requiresGuild: false,
+      },
+    } as unknown as jest.Mocked<ICommand>;
+
+    mockInteraction = {
+      isChatInputCommand: jest.fn().mockReturnValue(true),
+      commandName: 'test-command',
+      user: {
+        id: '123456789012345678',
+        username: 'testuser',
+        globalName: 'Test User',
+        avatar: 'avatar_hash',
+      },
+      guildId: null,
+      channelId: 'channel-123',
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      followUp: jest.fn().mockResolvedValue(undefined),
+      replied: false,
+      deferred: false,
+      inGuild: jest.fn().mockReturnValue(false),
+      member: null,
+    } as unknown as jest.Mocked<ChatInputCommandInteraction>;
+
+    mockCommandRegistry.get.mockReturnValue(mockCommand);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('User ID Restriction', () => {
+    it('should allow command execution when ALLOWED_USER_ID is not set', async () => {
+      // Arrange
+      mockConfigService.allowedUserId = undefined;
+      const event = createInteractionCreateEvent(
+        mockCommandRegistry,
+        mockPermissionValidator,
+        mockPermissionLogger,
+        mockApiService,
+        mockCooldownService,
+        mockConfigService
+      );
+
+      // Act
+      await event.execute(mockInteraction);
+
+      // Assert
+      expect(mockCommand.execute).toHaveBeenCalled();
+      expect(mockInteraction.reply).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: 'You do not have permission to use this command',
+        })
+      );
+    });
+
+    it('should allow command execution when user ID matches ALLOWED_USER_ID', async () => {
+      // Arrange
+      const allowedUserId = '123456789012345678';
+      mockConfigService.allowedUserId = allowedUserId;
+      mockInteraction.user.id = allowedUserId;
+
+      const event = createInteractionCreateEvent(
+        mockCommandRegistry,
+        mockPermissionValidator,
+        mockPermissionLogger,
+        mockApiService,
+        mockCooldownService,
+        mockConfigService
+      );
+
+      // Act
+      await event.execute(mockInteraction);
+
+      // Assert
+      expect(mockCommand.execute).toHaveBeenCalled();
+      expect(mockInteraction.reply).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: 'You do not have permission to use this command',
+        })
+      );
+    });
+
+    it('should deny command execution when user ID does not match ALLOWED_USER_ID', async () => {
+      // Arrange
+      const allowedUserId = '354474826192388127';
+      mockConfigService.allowedUserId = allowedUserId;
+      mockInteraction.user.id = '999999999999999999'; // Different user
+
+      const event = createInteractionCreateEvent(
+        mockCommandRegistry,
+        mockPermissionValidator,
+        mockPermissionLogger,
+        mockApiService,
+        mockCooldownService,
+        mockConfigService
+      );
+
+      // Act
+      await event.execute(mockInteraction);
+
+      // Assert
+      expect(mockCommand.execute).not.toHaveBeenCalled();
+      expect(mockInteraction.reply).toHaveBeenCalledWith({
+        content: 'You do not have permission to use this command',
+        ephemeral: true,
+      });
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Unauthorized command access attempt',
+        expect.objectContaining({
+          userId: '999999999999999999',
+          commandName: 'test-command',
+        })
+      );
+    });
+
+    it('should log unauthorized access attempt with correct details', async () => {
+      // Arrange
+      const allowedUserId = '354474826192388127';
+      mockConfigService.allowedUserId = allowedUserId;
+      mockInteraction.user.id = '999999999999999999';
+      mockInteraction.guildId = 'guild-123';
+
+      const event = createInteractionCreateEvent(
+        mockCommandRegistry,
+        mockPermissionValidator,
+        mockPermissionLogger,
+        mockApiService,
+        mockCooldownService,
+        mockConfigService
+      );
+
+      // Act
+      await event.execute(mockInteraction);
+
+      // Assert
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Unauthorized command access attempt',
+        expect.objectContaining({
+          userId: '999999999999999999',
+          username: 'testuser',
+          commandName: 'test-command',
+          guildId: 'guild-123',
+          channelId: 'channel-123',
+        })
+      );
+    });
+
+    it('should check user ID before any other permission checks', async () => {
+      // Arrange
+      const allowedUserId = '354474826192388127';
+      mockConfigService.allowedUserId = allowedUserId;
+      mockInteraction.user.id = '999999999999999999';
+
+      const event = createInteractionCreateEvent(
+        mockCommandRegistry,
+        mockPermissionValidator,
+        mockPermissionLogger,
+        mockApiService,
+        mockCooldownService,
+        mockConfigService
+      );
+
+      // Act
+      await event.execute(mockInteraction);
+
+      // Assert
+      // Should not call API service for guild settings
+      expect(mockApiService.getGuildSettings).not.toHaveBeenCalled();
+      // Should not check cooldown
+      expect(mockCooldownService.checkCooldown).not.toHaveBeenCalled();
+      // Should not validate permissions
+      expect(mockPermissionValidator.validateCommandPermissions).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Event Name', () => {
+    it('should return correct event name', () => {
+      const event = createInteractionCreateEvent(
+        mockCommandRegistry,
+        mockPermissionValidator,
+        mockPermissionLogger,
+        mockApiService,
+        mockCooldownService,
+        mockConfigService
+      );
+
+      expect(event.name).toBe(Events.InteractionCreate);
+    });
+  });
+});
+


### PR DESCRIPTION
## Overview
Implements user ID whitelist that restricts all bot commands to only the Discord user ID `354474826192388127`. This check happens early in the interaction flow, before channel restrictions, cooldowns, and other permission checks.

## Changes
- Add `ALLOWED_USER_ID` environment variable for user restriction
- Add user ID validation in interaction handler before other checks
- Update ConfigService to expose allowedUserId getter
- Add comprehensive tests for user restriction feature
- Update .env.example with placeholder for ALLOWED_USER_ID
- Configure authorized user ID in .env file

## Implementation Details
- User ID check is placed early in `interactionCreate.ts` right after command lookup
- If `ALLOWED_USER_ID` is not set, restriction is disabled (backward compatible)
- Unauthorized access attempts are logged for security monitoring
- Generic error message used to avoid revealing restriction mechanism

## Testing
- ✅ Allowed user can execute commands
- ✅ Unauthorized users are denied with correct error message
- ✅ When `ALLOWED_USER_ID` is not set, all users can use commands
- ✅ Unauthorized attempts are logged properly
- ✅ Environment variable validation works correctly