### PR TITLE
feat(commands): add Discord slash commands with interceptors and error handling

### DIFF
--- a/src/api/api.service.ts
+++ b/src/api/api.service.ts
@@ -536,4 +536,31 @@ export class ApiService {
       this.transformError(error);
     }
   }
+
+  /**
+   * Process trackers for a guild - triggers API to scrape/process tracker data
+   * Single Responsibility: HTTP call to process trackers for a guild
+   */
+  async processTrackers(guildId: string): Promise<{
+    processed: number;
+    trackers: string[];
+  }> {
+    try {
+      const response = await firstValueFrom(
+        this.httpService.post('/internal/trackers/process', {
+          guildId,
+        }),
+      );
+      if (!response.data) {
+        throw new ApiError('API returned no data', response.status, 'NO_DATA');
+      }
+      return response.data as { processed: number; trackers: string[] };
+    } catch (error: unknown) {
+      this.logger.error(
+        `Failed to process trackers for guild ${guildId}:`,
+        error,
+      );
+      this.transformError(error);
+    }
+  }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -7,6 +7,7 @@ import { ApiModule } from '../api/api.module';
 import { DiscordModule } from '../discord/discord.module';
 import { GuildModule } from '../guild/guild.module';
 import { MemberModule } from '../member/member.module';
+import { CommandsModule } from '../commands/commands.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { MemberModule } from '../member/member.module';
     DiscordModule,
     GuildModule,
     MemberModule,
+    CommandsModule,
     ThrottlerModule.forRoot([
       {
         ttl: 60000,

--- a/src/commands/add-tracker.command.spec.ts
+++ b/src/commands/add-tracker.command.spec.ts
@@ -1,0 +1,317 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AddTrackerCommand } from './add-tracker.command';
+import { ApiService } from '../api/api.service';
+import { AxiosError } from 'axios';
+import type { SlashCommandContext } from 'necord';
+import { ChatInputCommandInteraction, User } from 'discord.js';
+
+describe('AddTrackerCommand', () => {
+  let command: AddTrackerCommand;
+  let apiService: jest.Mocked<ApiService>;
+  let module: TestingModule;
+
+  const createMockInteraction = (
+    userId: string,
+    username: string,
+    trackerUrl: string,
+    options: {
+      deferred?: boolean;
+      replied?: boolean;
+      channelId?: string | null;
+      globalName?: string | null;
+      avatar?: string | null;
+    } = {},
+  ): ChatInputCommandInteraction => {
+    const {
+      deferred = false,
+      replied = false,
+      channelId = '123456789012345678',
+      globalName = null,
+      avatar = null,
+    } = options;
+
+    const mockUser = {
+      id: userId,
+      username,
+      globalName,
+      avatar,
+    } as User;
+
+    return {
+      user: mockUser,
+      options: {
+        getString: jest.fn().mockReturnValue(trackerUrl),
+      },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferred,
+      replied,
+      channelId,
+      token: 'test-token',
+    } as unknown as ChatInputCommandInteraction;
+  };
+
+  beforeEach(async () => {
+    const mockApiService = {
+      addTracker: jest.fn(),
+    };
+
+    module = await Test.createTestingModule({
+      providers: [
+        AddTrackerCommand,
+        {
+          provide: ApiService,
+          useValue: mockApiService,
+        },
+      ],
+    }).compile();
+
+    command = module.get<AddTrackerCommand>(AddTrackerCommand);
+    apiService = module.get(ApiService);
+
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  it('should be defined', () => {
+    expect(command).toBeDefined();
+  });
+
+  describe('onAddTracker', () => {
+    it('should successfully add a tracker and send success embed', async () => {
+      const interaction = createMockInteraction(
+        '111111111111111111',
+        'testuser',
+        'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+      );
+
+      const mockTrackerResponse = {
+        url: 'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+        platform: 'steam',
+        username: 'testuser',
+        scrapingStatus: 'PENDING',
+      };
+
+      apiService.addTracker.mockResolvedValue(mockTrackerResponse);
+
+      await command.onAddTracker([interaction] as SlashCommandContext);
+
+      expect(interaction.deferReply).toHaveBeenCalledWith({
+        ephemeral: true,
+      });
+      expect(apiService.addTracker).toHaveBeenCalledWith(
+        '111111111111111111',
+        'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+        {
+          username: 'testuser',
+          globalName: undefined,
+          avatar: undefined,
+        },
+        '123456789012345678',
+        'test-token',
+      );
+      expect(interaction.editReply).toHaveBeenCalled();
+      const editCall = (interaction.editReply as jest.Mock).mock.calls[0][0];
+      expect(editCall.embeds).toBeDefined();
+      expect(editCall.embeds[0].data.title).toBe(
+        '✅ Tracker Added Successfully',
+      );
+    });
+
+    it('should handle tracker response with missing optional fields', async () => {
+      const interaction = createMockInteraction(
+        '111111111111111111',
+        'testuser',
+        'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+      );
+
+      const mockTrackerResponse = {
+        url: undefined,
+        platform: undefined,
+        username: undefined,
+        scrapingStatus: undefined,
+      };
+
+      apiService.addTracker.mockResolvedValue(mockTrackerResponse);
+
+      await command.onAddTracker([interaction] as SlashCommandContext);
+
+      expect(interaction.editReply).toHaveBeenCalled();
+      const editCall = (interaction.editReply as jest.Mock).mock.calls[0][0];
+      expect(editCall.embeds[0].data.fields).toBeDefined();
+      // Should use original URL when tracker.url is missing
+      expect(
+        editCall.embeds[0].data.fields.find(
+          (f: any) => f.name === 'Tracker URL',
+        )?.value,
+      ).toBe(
+        'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+      );
+    });
+
+    it('should include user globalName and avatar when available', async () => {
+      const interaction = createMockInteraction(
+        '111111111111111111',
+        'testuser',
+        'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+        {
+          globalName: 'Test Global Name',
+          avatar: 'avatar-hash',
+        },
+      );
+
+      const mockTrackerResponse = {
+        url: 'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+        platform: 'steam',
+        username: 'testuser',
+        scrapingStatus: 'PENDING',
+      };
+
+      apiService.addTracker.mockResolvedValue(mockTrackerResponse);
+
+      await command.onAddTracker([interaction] as SlashCommandContext);
+
+      expect(apiService.addTracker).toHaveBeenCalledWith(
+        '111111111111111111',
+        'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+        {
+          username: 'testuser',
+          globalName: 'Test Global Name',
+          avatar: 'avatar-hash',
+        },
+        '123456789012345678',
+        'test-token',
+      );
+    });
+
+    it('should handle AxiosError with response data message', async () => {
+      const interaction = createMockInteraction(
+        '111111111111111111',
+        'testuser',
+        'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+      );
+
+      const axiosError = new AxiosError('API Error');
+      axiosError.response = {
+        data: {
+          message: 'Tracker limit reached. Maximum 4 trackers allowed.',
+        },
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config: {} as any,
+      };
+      apiService.addTracker.mockRejectedValue(axiosError);
+
+      await command.onAddTracker([interaction] as SlashCommandContext);
+
+      expect(interaction.deferReply).toHaveBeenCalled();
+      expect(interaction.editReply).toHaveBeenCalled();
+      const editCall = (interaction.editReply as jest.Mock).mock.calls[0][0];
+      expect(editCall.embeds[0].data.title).toBe('❌ Add Tracker Failed');
+      expect(editCall.embeds[0].data.description).toBe(
+        'Tracker limit reached. Maximum 4 trackers allowed.',
+      );
+    });
+
+    it('should handle AxiosError without response data message', async () => {
+      const interaction = createMockInteraction(
+        '111111111111111111',
+        'testuser',
+        'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+      );
+
+      const axiosError = new AxiosError('API Error');
+      axiosError.response = {
+        data: {},
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: {},
+        config: {} as any,
+      };
+      apiService.addTracker.mockRejectedValue(axiosError);
+
+      await command.onAddTracker([interaction] as SlashCommandContext);
+
+      expect(interaction.editReply).toHaveBeenCalled();
+      const editCall = (interaction.editReply as jest.Mock).mock.calls[0][0];
+      expect(editCall.embeds[0].data.title).toBe('❌ Add Tracker Failed');
+      expect(editCall.embeds[0].data.description).toBe(
+        'An error occurred while adding the tracker. Please try again.',
+      );
+    });
+
+    it('should handle generic Error with message', async () => {
+      const interaction = createMockInteraction(
+        '111111111111111111',
+        'testuser',
+        'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+      );
+
+      const error = new Error('Network timeout');
+      apiService.addTracker.mockRejectedValue(error);
+
+      await command.onAddTracker([interaction] as SlashCommandContext);
+
+      expect(interaction.editReply).toHaveBeenCalled();
+      const editCall = (interaction.editReply as jest.Mock).mock.calls[0][0];
+      expect(editCall.embeds[0].data.description).toBe('Network timeout');
+    });
+
+    it('should handle unknown error type', async () => {
+      const interaction = createMockInteraction(
+        '111111111111111111',
+        'testuser',
+        'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+      );
+
+      apiService.addTracker.mockRejectedValue('String error');
+
+      await command.onAddTracker([interaction] as SlashCommandContext);
+
+      expect(interaction.editReply).toHaveBeenCalled();
+      const editCall = (interaction.editReply as jest.Mock).mock.calls[0][0];
+      expect(editCall.embeds[0].data.description).toBe(
+        'An error occurred while adding the tracker. Please try again.',
+      );
+    });
+
+    it('should handle null channelId', async () => {
+      const interaction = createMockInteraction(
+        '111111111111111111',
+        'testuser',
+        'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+        {
+          channelId: null,
+        },
+      );
+
+      const mockTrackerResponse = {
+        url: 'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+        platform: 'steam',
+        username: 'testuser',
+        scrapingStatus: 'PENDING',
+      };
+
+      apiService.addTracker.mockResolvedValue(mockTrackerResponse);
+
+      await command.onAddTracker([interaction] as SlashCommandContext);
+
+      expect(apiService.addTracker).toHaveBeenCalledWith(
+        '111111111111111111',
+        'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+        {
+          username: 'testuser',
+          globalName: undefined,
+          avatar: undefined,
+        },
+        null,
+        'test-token',
+      );
+    });
+  });
+});

--- a/src/commands/add-tracker.command.ts
+++ b/src/commands/add-tracker.command.ts
@@ -1,0 +1,128 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SlashCommand, Context } from 'necord';
+import type { SlashCommandContext } from 'necord';
+import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
+import { ApiService } from '../api/api.service';
+import { AxiosError } from 'axios';
+
+/**
+ * AddTrackerCommand - Single Responsibility: Handle /add-tracker command
+ *
+ * Allows registered users to add an additional tracker URL (up to 4 total).
+ */
+
+interface TrackerResponse {
+  url?: string;
+  platform?: string;
+  username?: string;
+  scrapingStatus?: string;
+}
+
+@Injectable()
+export class AddTrackerCommand {
+  private readonly logger = new Logger(AddTrackerCommand.name);
+
+  constructor(private readonly apiService: ApiService) {}
+
+  @SlashCommand(
+    new SlashCommandBuilder()
+      .setName('add-tracker')
+      .setDescription('Add an additional tracker URL (up to 4 total)')
+      .addStringOption((option) =>
+        option
+          .setName('tracker_url')
+          .setDescription('Your tracker profile URL')
+          .setRequired(true),
+      )
+      .toJSON(),
+  )
+  public async onAddTracker(
+    @Context() [interaction]: SlashCommandContext,
+  ): Promise<void> {
+    const url = interaction.options.getString('tracker_url', true);
+    const userId = interaction.user.id;
+    const userData = {
+      username: interaction.user.username,
+      globalName: interaction.user.globalName || undefined,
+      avatar: interaction.user.avatar || undefined,
+    };
+
+    await interaction.deferReply({ ephemeral: true });
+
+    try {
+      // Capture channel context for ephemeral follow-up messages
+      const channelId = interaction.channelId;
+      const interactionToken = interaction.token;
+
+      const tracker = (await this.apiService.addTracker(
+        userId,
+        url,
+        userData,
+        channelId,
+        interactionToken,
+      )) as TrackerResponse;
+
+      const embed = new EmbedBuilder()
+        .setTitle('✅ Tracker Added Successfully')
+        .setDescription(
+          'Your tracker has been added. Data is being collected in the background.',
+        )
+        .setColor(0x00ff00)
+        .addFields(
+          {
+            name: 'Tracker URL',
+            value: tracker.url || url,
+            inline: false,
+          },
+          {
+            name: 'Platform',
+            value: tracker.platform || 'Unknown',
+            inline: true,
+          },
+          {
+            name: 'Username',
+            value: tracker.username || 'Unknown',
+            inline: true,
+          },
+          {
+            name: 'Status',
+            value: tracker.scrapingStatus || 'PENDING',
+            inline: true,
+          },
+        )
+        .setFooter({
+          text: 'You can check your tracker status in the web dashboard.',
+        })
+        .setTimestamp();
+
+      await interaction.editReply({ embeds: [embed] });
+    } catch (error: unknown) {
+      this.logger.error('Failed to add tracker:', error);
+
+      let errorMessage =
+        'An error occurred while adding the tracker. Please try again.';
+      if (error instanceof AxiosError && error.response?.data) {
+        const data = error.response.data as { message?: string };
+        if (data.message) {
+          errorMessage = data.message;
+        }
+      } else if (error instanceof Error && error.message) {
+        errorMessage = error.message;
+      }
+
+      const embed = new EmbedBuilder()
+        .setTitle('❌ Add Tracker Failed')
+        .setDescription(errorMessage)
+        .setColor(0xff0000)
+        .addFields({
+          name: 'Tip',
+          value:
+            "You can have up to 4 trackers total. Use /register if you haven't registered any trackers yet.",
+          inline: false,
+        })
+        .setTimestamp();
+
+      await interaction.editReply({ embeds: [embed] });
+    }
+  }
+}

--- a/src/commands/commands.module.spec.ts
+++ b/src/commands/commands.module.spec.ts
@@ -1,0 +1,34 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommandsModule } from './commands.module';
+
+describe('CommandsModule', () => {
+  let module: TestingModule;
+
+  beforeEach(async () => {
+    // Set minimal environment variables for module compilation
+    const originalEnv = process.env;
+    process.env = {
+      ...originalEnv,
+      DISCORD_TOKEN: 'test-token',
+      BOT_API_KEY: 'test-api-key',
+    };
+
+    try {
+      module = await Test.createTestingModule({
+        imports: [CommandsModule],
+      }).compile();
+
+      expect(module).toBeDefined();
+    } finally {
+      process.env = originalEnv;
+    }
+  });
+
+  afterEach(async () => {
+    await module?.close();
+  });
+
+  it('should compile successfully', () => {
+    expect(module).toBeDefined();
+  });
+});

--- a/src/commands/commands.module.ts
+++ b/src/commands/commands.module.ts
@@ -1,0 +1,34 @@
+import { Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import { ApiModule } from '../api/api.module';
+import { ConfigModule } from '../config/config.module';
+import { ConfigCommand } from './config.command';
+import { HelpCommand } from './help.command';
+import { RegisterCommand } from './register.command';
+import { AddTrackerCommand } from './add-tracker.command';
+import { ProcessTrackersCommand } from './process-trackers.command';
+import { CooldownInterceptor } from './interceptors/cooldown/cooldown.interceptor';
+import { ErrorHandlingInterceptor } from './interceptors/error-handling/error-handling.interceptor';
+
+@Module({
+  imports: [ApiModule, ConfigModule],
+  providers: [
+    ConfigCommand,
+    HelpCommand,
+    RegisterCommand,
+    AddTrackerCommand,
+    ProcessTrackersCommand,
+    // Apply interceptors globally - they check for Discord interactions and skip if not found
+    // Note: Interceptors registered via APP_INTERCEPTOR don't need to be in providers array
+    // unless they need to be injected elsewhere. NestJS will instantiate them automatically.
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: CooldownInterceptor,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: ErrorHandlingInterceptor,
+    },
+  ],
+})
+export class CommandsModule {}

--- a/src/commands/config.command.spec.ts
+++ b/src/commands/config.command.spec.ts
@@ -1,0 +1,135 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigCommand } from './config.command';
+import { ConfigService } from '../config/config.service';
+import type { SlashCommandContext } from 'necord';
+import { ChatInputCommandInteraction } from 'discord.js';
+
+describe('ConfigCommand', () => {
+  let command: ConfigCommand;
+  let configService: jest.Mocked<ConfigService>;
+  let module: TestingModule;
+
+  const createMockInteraction = (
+    guildId: string | null = '123456789012345678',
+  ): ChatInputCommandInteraction => {
+    return {
+      guildId,
+      reply: jest.fn().mockResolvedValue(undefined),
+    } as unknown as ChatInputCommandInteraction;
+  };
+
+  beforeEach(async () => {
+    const mockConfigService = {
+      getDashboardUrl: jest.fn(),
+    };
+
+    module = await Test.createTestingModule({
+      providers: [
+        ConfigCommand,
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
+    }).compile();
+
+    command = module.get<ConfigCommand>(ConfigCommand);
+    configService = module.get(ConfigService);
+
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  it('should be defined', () => {
+    expect(command).toBeDefined();
+  });
+
+  describe('onConfig', () => {
+    it('should send dashboard URL with guild ID when both are available', async () => {
+      const interaction = createMockInteraction('123456789012345678');
+      configService.getDashboardUrl.mockReturnValue(
+        'https://dashboard.example.com',
+      );
+
+      await command.onConfig([interaction] as SlashCommandContext);
+
+      expect(configService.getDashboardUrl).toHaveBeenCalled();
+      expect(interaction.reply).toHaveBeenCalledWith({
+        embeds: expect.arrayContaining([
+          expect.objectContaining({
+            data: expect.objectContaining({
+              title: '⚙️ Bot Configuration',
+              description: expect.stringContaining(
+                'https://dashboard.example.com?guild=123456789012345678',
+              ),
+            }),
+          }),
+        ]),
+        ephemeral: true,
+      });
+    });
+
+    it('should send error message when dashboard URL is not configured', async () => {
+      const interaction = createMockInteraction('123456789012345678');
+      configService.getDashboardUrl.mockReturnValue(undefined);
+
+      await command.onConfig([interaction] as SlashCommandContext);
+
+      expect(interaction.reply).toHaveBeenCalledWith({
+        embeds: expect.arrayContaining([
+          expect.objectContaining({
+            data: expect.objectContaining({
+              title: '⚙️ Bot Configuration',
+              description:
+                'Dashboard is not configured. Please contact the bot administrator.',
+            }),
+          }),
+        ]),
+        ephemeral: true,
+      });
+    });
+
+    it('should send error message when guild ID is not available', async () => {
+      const interaction = createMockInteraction(null);
+      configService.getDashboardUrl.mockReturnValue(
+        'https://dashboard.example.com',
+      );
+
+      await command.onConfig([interaction] as SlashCommandContext);
+
+      expect(interaction.reply).toHaveBeenCalledWith({
+        embeds: expect.arrayContaining([
+          expect.objectContaining({
+            data: expect.objectContaining({
+              description:
+                'Dashboard is not configured. Please contact the bot administrator.',
+            }),
+          }),
+        ]),
+        ephemeral: true,
+      });
+    });
+
+    it('should send error message when both dashboard URL and guild ID are missing', async () => {
+      const interaction = createMockInteraction(null);
+      configService.getDashboardUrl.mockReturnValue(undefined);
+
+      await command.onConfig([interaction] as SlashCommandContext);
+
+      expect(interaction.reply).toHaveBeenCalledWith({
+        embeds: expect.arrayContaining([
+          expect.objectContaining({
+            data: expect.objectContaining({
+              description:
+                'Dashboard is not configured. Please contact the bot administrator.',
+            }),
+          }),
+        ]),
+        ephemeral: true,
+      });
+    });
+  });
+});

--- a/src/commands/config.command.ts
+++ b/src/commands/config.command.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { SlashCommand, Context } from 'necord';
+import type { SlashCommandContext } from 'necord';
+import { EmbedBuilder, PermissionFlagsBits } from 'discord.js';
+import { ConfigService } from '../config/config.service';
+
+/**
+ * ConfigCommand - Single Responsibility: Handle /config command
+ *
+ * Declarative permissions: Command declares requirements, doesn't enforce them.
+ * Provides dashboard link and configuration instructions.
+ */
+@Injectable()
+export class ConfigCommand {
+  constructor(private readonly configService: ConfigService) {}
+
+  @SlashCommand({
+    name: 'config',
+    description: 'Get the dashboard link to configure the bot',
+    defaultMemberPermissions: PermissionFlagsBits.Administrator,
+  })
+  public async onConfig(
+    @Context() [interaction]: SlashCommandContext,
+  ): Promise<void> {
+    const dashboardUrl = this.configService.getDashboardUrl();
+    const guildId = interaction.guildId;
+
+    const embed = new EmbedBuilder()
+      .setTitle('⚙️ Bot Configuration')
+      .setColor(0x00ff00);
+
+    if (dashboardUrl && guildId) {
+      const guildDashboardUrl = `${dashboardUrl}?guild=${guildId}`;
+      embed.setDescription(
+        `Configure the bot using the web dashboard:\n\n[Open Dashboard](${guildDashboardUrl})`,
+      );
+    } else {
+      embed.setDescription(
+        'Dashboard is not configured. Please contact the bot administrator.',
+      );
+    }
+
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+  }
+}

--- a/src/commands/help.command.spec.ts
+++ b/src/commands/help.command.spec.ts
@@ -1,0 +1,97 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HelpCommand } from './help.command';
+import type { SlashCommandContext } from 'necord';
+import { ChatInputCommandInteraction } from 'discord.js';
+
+describe('HelpCommand', () => {
+  let command: HelpCommand;
+  let module: TestingModule;
+
+  const createMockInteraction = (): ChatInputCommandInteraction => {
+    return {
+      reply: jest.fn().mockResolvedValue(undefined),
+    } as unknown as ChatInputCommandInteraction;
+  };
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      providers: [HelpCommand],
+    }).compile();
+
+    command = module.get<HelpCommand>(HelpCommand);
+
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  it('should be defined', () => {
+    expect(command).toBeDefined();
+  });
+
+  describe('onHelp', () => {
+    it('should send help embed with all commands', async () => {
+      const interaction = createMockInteraction();
+
+      await command.onHelp([interaction] as SlashCommandContext);
+
+      expect(interaction.reply).toHaveBeenCalledWith({
+        embeds: expect.arrayContaining([
+          expect.objectContaining({
+            data: expect.objectContaining({
+              title: '📖 Bot Commands',
+              description: 'Here are all available commands:',
+            }),
+          }),
+        ]),
+        ephemeral: true,
+      });
+
+      const replyCall = (interaction.reply as jest.Mock).mock.calls[0][0];
+      const embed = replyCall.embeds[0];
+      expect(embed.data.fields).toBeDefined();
+      expect(embed.data.fields.length).toBeGreaterThan(0);
+
+      // Verify all expected commands are present
+      const commandNames = embed.data.fields.map((field: any) => field.name);
+      expect(commandNames).toEqual(
+        expect.arrayContaining([
+          '/config',
+          '/help',
+          '/register',
+          '/add-tracker',
+          '/process-trackers',
+        ]),
+      );
+    });
+
+    it('should include command descriptions', async () => {
+      const interaction = createMockInteraction();
+
+      await command.onHelp([interaction] as SlashCommandContext);
+
+      const replyCall = (interaction.reply as jest.Mock).mock.calls[0][0];
+      const embed = replyCall.embeds[0];
+      const fields = embed.data.fields;
+
+      // Check that each command has a description
+      fields.forEach((field: any) => {
+        expect(field.value).toBeDefined();
+        expect(typeof field.value).toBe('string');
+        expect(field.value.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('should set correct embed color', async () => {
+      const interaction = createMockInteraction();
+
+      await command.onHelp([interaction] as SlashCommandContext);
+
+      const replyCall = (interaction.reply as jest.Mock).mock.calls[0][0];
+      const embed = replyCall.embeds[0];
+      expect(embed.data.color).toBe(0x00ff00);
+    });
+  });
+});

--- a/src/commands/help.command.ts
+++ b/src/commands/help.command.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@nestjs/common';
+import { SlashCommand, Context } from 'necord';
+import type { SlashCommandContext } from 'necord';
+import { EmbedBuilder } from 'discord.js';
+
+/**
+ * HelpCommand - Single Responsibility: Handle /help command
+ *
+ * Lists all available bot commands.
+ * Note: Command list is maintained manually since Necord auto-registers commands.
+ */
+@Injectable()
+export class HelpCommand {
+  // Static list of commands - maintain this when adding new commands
+  private readonly commands = [
+    {
+      name: 'config',
+      description: 'Get the dashboard link to configure the bot',
+    },
+    { name: 'help', description: 'Show all available bot commands' },
+    {
+      name: 'register',
+      description: 'Register up to 4 Rocket League tracker URLs',
+    },
+    {
+      name: 'add-tracker',
+      description: 'Add an additional tracker URL (up to 4 total)',
+    },
+    {
+      name: 'process-trackers',
+      description:
+        'Trigger tracker data processing for this server (super user only)',
+    },
+  ];
+
+  @SlashCommand({
+    name: 'help',
+    description: 'Show all available bot commands',
+  })
+  public async onHelp(
+    @Context() [interaction]: SlashCommandContext,
+  ): Promise<void> {
+    const embed = new EmbedBuilder()
+      .setTitle('📖 Bot Commands')
+      .setDescription('Here are all available commands:')
+      .setColor(0x00ff00);
+
+    this.commands.forEach((command) => {
+      embed.addFields({
+        name: `/${command.name}`,
+        value: command.description,
+        inline: false,
+      });
+    });
+
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+  }
+}

--- a/src/commands/interceptors/cooldown/cooldown.interceptor.spec.ts
+++ b/src/commands/interceptors/cooldown/cooldown.interceptor.spec.ts
@@ -1,0 +1,353 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  ExecutionContext,
+  CallHandler,
+  ForbiddenException,
+} from '@nestjs/common';
+import { CooldownInterceptor } from './cooldown.interceptor';
+import { of } from 'rxjs';
+import { ChatInputCommandInteraction, User } from 'discord.js';
+
+describe('CooldownInterceptor', () => {
+  let interceptor: CooldownInterceptor;
+  let module: TestingModule;
+
+  const createMockInteraction = (
+    userId: string,
+    commandName: string,
+    options: {
+      deferred?: boolean;
+      replied?: boolean;
+    } = {},
+  ): ChatInputCommandInteraction => {
+    const { deferred = false, replied = false } = options;
+
+    const mockUser = {
+      id: userId,
+    } as User;
+
+    return {
+      user: mockUser,
+      commandName,
+      deferred,
+      replied,
+      reply: jest.fn().mockResolvedValue(undefined),
+      followUp: jest.fn().mockResolvedValue(undefined),
+    } as unknown as ChatInputCommandInteraction;
+  };
+
+  const createMockExecutionContext = (
+    interaction: ChatInputCommandInteraction | null,
+  ): ExecutionContext => {
+    return {
+      getArgs: jest.fn().mockReturnValue(interaction ? [interaction] : []),
+    } as unknown as ExecutionContext;
+  };
+
+  const createMockCallHandler = (): CallHandler => {
+    return {
+      handle: jest.fn().mockReturnValue(of('success')),
+    } as unknown as CallHandler;
+  };
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      providers: [CooldownInterceptor],
+    }).compile();
+
+    interceptor = module.get<CooldownInterceptor>(CooldownInterceptor);
+
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    jest.useRealTimers();
+    await module.close();
+  });
+
+  it('should be defined', () => {
+    expect(interceptor).toBeDefined();
+  });
+
+  describe('intercept', () => {
+    it('should allow command execution when no cooldown exists', (done) => {
+      const interaction = createMockInteraction('111111111111111111', 'test');
+      const context = createMockExecutionContext(interaction);
+      const handler = createMockCallHandler();
+
+      interceptor.intercept(context, handler).subscribe({
+        next: (value) => {
+          expect(value).toBe('success');
+          expect(handler.handle).toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+
+    it('should allow command execution when cooldown has expired', (done) => {
+      const interaction = createMockInteraction('111111111111111111', 'test');
+      const context = createMockExecutionContext(interaction);
+      const handler = createMockCallHandler();
+
+      // First call sets cooldown
+      interceptor.intercept(context, handler).subscribe();
+
+      // Advance time past cooldown (3 seconds)
+      jest.advanceTimersByTime(3100);
+
+      // Second call should succeed
+      interceptor.intercept(context, handler).subscribe({
+        next: (value) => {
+          expect(value).toBe('success');
+          expect(handler.handle).toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+
+    it('should block command execution when cooldown is active', (done) => {
+      const interaction = createMockInteraction('111111111111111111', 'test');
+      const context = createMockExecutionContext(interaction);
+      const handler = createMockCallHandler();
+
+      // First call sets cooldown
+      interceptor.intercept(context, handler).subscribe({
+        complete: () => {
+          // Second call immediately after should be blocked
+          interceptor.intercept(context, handler).subscribe({
+            error: (error) => {
+              expect(error).toBeInstanceOf(ForbiddenException);
+              expect(error.message).toBe('Command is on cooldown');
+              expect(handler.handle).toHaveBeenCalledTimes(1); // Only first call
+              done();
+            },
+            complete: () => {
+              done(new Error('Expected error but got completion'));
+            },
+          });
+        },
+      });
+    });
+
+    it('should send cooldown message via reply when interaction not deferred or replied', (done) => {
+      const interaction = createMockInteraction('111111111111111111', 'test', {
+        deferred: false,
+        replied: false,
+      });
+      const context = createMockExecutionContext(interaction);
+      const handler = createMockCallHandler();
+
+      // First call sets cooldown
+      interceptor.intercept(context, handler).subscribe();
+
+      // Second call should send reply
+      interceptor.intercept(context, handler).subscribe({
+        error: () => {
+          expect(interaction.reply).toHaveBeenCalledWith({
+            content: expect.stringContaining('Please wait'),
+            ephemeral: true,
+          });
+          done();
+        },
+      });
+    });
+
+    it('should send cooldown message via followUp when interaction is deferred', (done) => {
+      const interaction = createMockInteraction('111111111111111111', 'test', {
+        deferred: true,
+        replied: false,
+      });
+      const context = createMockExecutionContext(interaction);
+      const handler = createMockCallHandler();
+
+      // First call sets cooldown
+      interceptor.intercept(context, handler).subscribe();
+
+      // Second call should send followUp
+      interceptor.intercept(context, handler).subscribe({
+        error: () => {
+          expect(interaction.followUp).toHaveBeenCalledWith({
+            content: expect.stringContaining('Please wait'),
+            ephemeral: true,
+          });
+          expect(interaction.reply).not.toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+
+    it('should send cooldown message via followUp when interaction is replied', (done) => {
+      const interaction = createMockInteraction('111111111111111111', 'test', {
+        deferred: false,
+        replied: true,
+      });
+      const context = createMockExecutionContext(interaction);
+      const handler = createMockCallHandler();
+
+      // First call sets cooldown
+      interceptor.intercept(context, handler).subscribe();
+
+      // Second call should send followUp
+      interceptor.intercept(context, handler).subscribe({
+        error: () => {
+          expect(interaction.followUp).toHaveBeenCalledWith({
+            content: expect.stringContaining('Please wait'),
+            ephemeral: true,
+          });
+          expect(interaction.reply).not.toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+
+    it('should handle different users independently', (done) => {
+      const interaction1 = createMockInteraction('111111111111111111', 'test');
+      const interaction2 = createMockInteraction('222222222222222222', 'test');
+      const context1 = createMockExecutionContext(interaction1);
+      const context2 = createMockExecutionContext(interaction2);
+      const handler = createMockCallHandler();
+
+      // First user sets cooldown
+      interceptor.intercept(context1, handler).subscribe();
+
+      // Second user should be able to execute immediately
+      interceptor.intercept(context2, handler).subscribe({
+        next: (value) => {
+          expect(value).toBe('success');
+          expect(handler.handle).toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+
+    it('should handle different commands independently', (done) => {
+      const interaction1 = createMockInteraction('111111111111111111', 'test1');
+      const interaction2 = createMockInteraction('111111111111111111', 'test2');
+      const context1 = createMockExecutionContext(interaction1);
+      const context2 = createMockExecutionContext(interaction2);
+      const handler = createMockCallHandler();
+
+      // First command sets cooldown
+      interceptor.intercept(context1, handler).subscribe();
+
+      // Second command should be able to execute immediately
+      interceptor.intercept(context2, handler).subscribe({
+        next: (value) => {
+          expect(value).toBe('success');
+          expect(handler.handle).toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+
+    it('should skip cooldown check for non-Discord interactions', (done) => {
+      const context = createMockExecutionContext(null);
+      const handler = createMockCallHandler();
+
+      interceptor.intercept(context, handler).subscribe({
+        next: (value) => {
+          expect(value).toBe('success');
+          expect(handler.handle).toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+
+    it('should handle reply errors gracefully', (done) => {
+      const interaction = createMockInteraction('111111111111111111', 'test', {
+        deferred: false,
+        replied: false,
+      });
+      (interaction.reply as jest.Mock).mockRejectedValue(
+        new Error('Reply failed'),
+      );
+      const context = createMockExecutionContext(interaction);
+      const handler = createMockCallHandler();
+
+      // First call sets cooldown
+      interceptor.intercept(context, handler).subscribe();
+
+      // Second call should still throw ForbiddenException even if reply fails
+      interceptor.intercept(context, handler).subscribe({
+        error: (error) => {
+          expect(error).toBeInstanceOf(ForbiddenException);
+          expect(interaction.reply).toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+
+    it('should handle followUp errors gracefully', (done) => {
+      const interaction = createMockInteraction('111111111111111111', 'test', {
+        deferred: true,
+        replied: false,
+      });
+      (interaction.followUp as jest.Mock).mockRejectedValue(
+        new Error('FollowUp failed'),
+      );
+      const context = createMockExecutionContext(interaction);
+      const handler = createMockCallHandler();
+
+      // First call sets cooldown
+      interceptor.intercept(context, handler).subscribe();
+
+      // Second call should still throw ForbiddenException even if followUp fails
+      interceptor.intercept(context, handler).subscribe({
+        error: (error) => {
+          expect(error).toBeInstanceOf(ForbiddenException);
+          expect(interaction.followUp).toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+
+    it('should cleanup old cooldowns when map size exceeds 1000', () => {
+      const handler = createMockCallHandler();
+
+      // Create many cooldowns
+      for (let i = 0; i < 1001; i++) {
+        const interaction = createMockInteraction(
+          `${i}`.padStart(18, '0'),
+          'test',
+        );
+        const context = createMockExecutionContext(interaction);
+        interceptor.intercept(context, handler).subscribe();
+      }
+
+      // Advance time past cooldown
+      jest.advanceTimersByTime(3100);
+
+      // Next call should trigger cleanup
+      const interaction = createMockInteraction('999999999999999999', 'test');
+      const context = createMockExecutionContext(interaction);
+      interceptor.intercept(context, handler).subscribe({
+        next: (value) => {
+          expect(value).toBe('success');
+          expect(handler.handle).toHaveBeenCalled();
+        },
+      });
+    });
+  });
+
+  describe('onApplicationShutdown', () => {
+    it('should cleanup cooldowns on shutdown', () => {
+      const interaction = createMockInteraction('111111111111111111', 'test');
+      const context = createMockExecutionContext(interaction);
+      const handler = createMockCallHandler();
+
+      // Set a cooldown
+      interceptor.intercept(context, handler).subscribe();
+
+      // Shutdown should clear cooldowns
+      interceptor.onApplicationShutdown();
+
+      // After shutdown, should be able to execute immediately
+      interceptor.intercept(context, handler).subscribe({
+        next: (value) => {
+          expect(value).toBe('success');
+        },
+      });
+    });
+  });
+});

--- a/src/commands/interceptors/cooldown/cooldown.interceptor.ts
+++ b/src/commands/interceptors/cooldown/cooldown.interceptor.ts
@@ -1,0 +1,121 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+  Logger,
+  ForbiddenException,
+  OnApplicationShutdown,
+} from '@nestjs/common';
+import { Observable, throwError } from 'rxjs';
+import { ChatInputCommandInteraction } from 'discord.js';
+
+/**
+ * CooldownInterceptor - Prevents command spam by enforcing cooldown periods
+ * Tracks cooldowns per user per command
+ */
+@Injectable()
+export class CooldownInterceptor
+  implements NestInterceptor, OnApplicationShutdown
+{
+  private readonly logger = new Logger(CooldownInterceptor.name);
+  private readonly cooldowns = new Map<string, number>();
+  private readonly cooldownDuration = 3000; // 3 seconds default cooldown
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const interaction = this.getInteraction(context);
+    if (!interaction) {
+      // Not a Discord interaction, skip cooldown check
+      return next.handle();
+    }
+
+    const cooldownKey = this.getCooldownKey(interaction);
+    const now = Date.now();
+    const cooldownEnd = this.cooldowns.get(cooldownKey);
+
+    if (cooldownEnd && now < cooldownEnd) {
+      const remaining = ((cooldownEnd - now) / 1000).toFixed(1);
+      this.logger.debug(
+        `Cooldown active for user ${interaction.user.id} on command ${interaction.commandName}: ${remaining}s remaining`,
+      );
+
+      if (interaction.deferred || interaction.replied) {
+        interaction
+          .followUp({
+            content: `⏱️ Please wait ${remaining} seconds before using this command again.`,
+            ephemeral: true,
+          })
+          .catch((err) => {
+            this.logger.error('Failed to send cooldown message:', err);
+          });
+      } else {
+        interaction
+          .reply({
+            content: `⏱️ Please wait ${remaining} seconds before using this command again.`,
+            ephemeral: true,
+          })
+          .catch((err) => {
+            this.logger.error('Failed to send cooldown message:', err);
+          });
+      }
+
+      return throwError(() => new ForbiddenException('Command is on cooldown'));
+    }
+
+    this.cooldowns.set(cooldownKey, now + this.cooldownDuration);
+
+    // Clean up old cooldowns periodically (optional optimization)
+    if (this.cooldowns.size > 1000) {
+      this.cleanupCooldowns(now);
+    }
+
+    return next.handle();
+  }
+
+  private getInteraction(
+    context: ExecutionContext,
+  ): ChatInputCommandInteraction | null {
+    const args = context.getArgs();
+    if (args && args.length > 0) {
+      const firstArg = args[0] as unknown;
+      if (
+        firstArg &&
+        typeof firstArg === 'object' &&
+        'commandName' in firstArg &&
+        'user' in firstArg
+      ) {
+        return firstArg as ChatInputCommandInteraction;
+      }
+    }
+    return null;
+  }
+
+  private getCooldownKey(interaction: ChatInputCommandInteraction): string {
+    return `${interaction.user.id}:${interaction.commandName}`;
+  }
+
+  private cleanupCooldowns(now: number): void {
+    let cleaned = 0;
+    for (const [key, endTime] of this.cooldowns.entries()) {
+      if (now >= endTime) {
+        this.cooldowns.delete(key);
+        cleaned++;
+      }
+    }
+    if (cleaned > 0) {
+      this.logger.debug(`Cleaned up ${cleaned} expired cooldowns`);
+    }
+  }
+
+  /**
+   * Cleanup cooldowns on application shutdown
+   * NestJS lifecycle hook - guaranteed to run during graceful shutdown
+   */
+  onApplicationShutdown(): void {
+    const size = this.cooldowns.size;
+    this.cooldowns.clear();
+    if (size > 0) {
+      this.logger.debug(`Cleaned up ${size} cooldown entries on shutdown`);
+    }
+  }
+}

--- a/src/commands/interceptors/error-handling/error-handling.interceptor.spec.ts
+++ b/src/commands/interceptors/error-handling/error-handling.interceptor.spec.ts
@@ -1,0 +1,326 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext, CallHandler } from '@nestjs/common';
+import { ErrorHandlingInterceptor } from './error-handling.interceptor';
+import { throwError, of } from 'rxjs';
+import { ChatInputCommandInteraction, User } from 'discord.js';
+import { AxiosError } from 'axios';
+
+describe('ErrorHandlingInterceptor', () => {
+  let interceptor: ErrorHandlingInterceptor;
+  let module: TestingModule;
+
+  const createMockInteraction = (
+    options: {
+      deferred?: boolean;
+      replied?: boolean;
+    } = {},
+  ): ChatInputCommandInteraction => {
+    const { deferred = false, replied = false } = options;
+
+    const mockUser = {
+      id: '111111111111111111',
+    } as User;
+
+    return {
+      user: mockUser,
+      commandName: 'test',
+      deferred,
+      replied,
+      reply: jest.fn().mockResolvedValue(undefined),
+      followUp: jest.fn().mockResolvedValue(undefined),
+    } as unknown as ChatInputCommandInteraction;
+  };
+
+  const createMockExecutionContext = (
+    interaction: ChatInputCommandInteraction | null,
+  ): ExecutionContext => {
+    return {
+      getArgs: jest.fn().mockReturnValue(interaction ? [interaction] : []),
+    } as unknown as ExecutionContext;
+  };
+
+  const createMockCallHandler = (
+    shouldError: boolean = false,
+    error?: any,
+  ): CallHandler => {
+    return {
+      handle: jest
+        .fn()
+        .mockReturnValue(
+          shouldError
+            ? throwError(() => error || new Error('Test error'))
+            : of('success'),
+        ),
+    } as unknown as CallHandler;
+  };
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      providers: [ErrorHandlingInterceptor],
+    }).compile();
+
+    interceptor = module.get<ErrorHandlingInterceptor>(
+      ErrorHandlingInterceptor,
+    );
+
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  it('should be defined', () => {
+    expect(interceptor).toBeDefined();
+  });
+
+  describe('intercept', () => {
+    it('should pass through successful responses', (done) => {
+      const interaction = createMockInteraction();
+      const context = createMockExecutionContext(interaction);
+      const handler = createMockCallHandler(false);
+
+      interceptor.intercept(context, handler).subscribe({
+        next: (value) => {
+          expect(value).toBe('success');
+          expect(interaction.reply).not.toHaveBeenCalled();
+          expect(interaction.followUp).not.toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+
+    it('should send error message via reply when interaction not deferred or replied', (done) => {
+      const interaction = createMockInteraction({
+        deferred: false,
+        replied: false,
+      });
+      const context = createMockExecutionContext(interaction);
+      const handler = createMockCallHandler(true, new Error('Test error'));
+
+      interceptor.intercept(context, handler).subscribe({
+        error: (error) => {
+          expect(error).toBeInstanceOf(Error);
+          expect(interaction.reply).toHaveBeenCalledWith({
+            embeds: expect.arrayContaining([
+              expect.objectContaining({
+                data: expect.objectContaining({
+                  title: '❌ Error',
+                }),
+              }),
+            ]),
+            ephemeral: true,
+          });
+          done();
+        },
+      });
+    });
+
+    it('should send error message via followUp when interaction is deferred', (done) => {
+      const interaction = createMockInteraction({
+        deferred: true,
+        replied: false,
+      });
+      const context = createMockExecutionContext(interaction);
+      const handler = createMockCallHandler(true, new Error('Test error'));
+
+      interceptor.intercept(context, handler).subscribe({
+        error: (error) => {
+          expect(error).toBeInstanceOf(Error);
+          expect(interaction.followUp).toHaveBeenCalledWith({
+            embeds: expect.arrayContaining([
+              expect.objectContaining({
+                data: expect.objectContaining({
+                  title: '❌ Error',
+                }),
+              }),
+            ]),
+            ephemeral: true,
+          });
+          expect(interaction.reply).not.toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+
+    it('should send error message via followUp when interaction is replied', (done) => {
+      const interaction = createMockInteraction({
+        deferred: false,
+        replied: true,
+      });
+      const context = createMockExecutionContext(interaction);
+      const handler = createMockCallHandler(true, new Error('Test error'));
+
+      interceptor.intercept(context, handler).subscribe({
+        error: (error) => {
+          expect(error).toBeInstanceOf(Error);
+          expect(interaction.followUp).toHaveBeenCalledWith({
+            embeds: expect.arrayContaining([
+              expect.objectContaining({
+                data: expect.objectContaining({
+                  title: '❌ Error',
+                }),
+              }),
+            ]),
+            ephemeral: true,
+          });
+          expect(interaction.reply).not.toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+
+    it('should extract error message from AxiosError with response data', (done) => {
+      const interaction = createMockInteraction();
+      const context = createMockExecutionContext(interaction);
+      const axiosError = new AxiosError('API Error');
+      axiosError.response = {
+        data: {
+          message: 'User-friendly error message',
+        },
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config: {} as any,
+      };
+      const handler = createMockCallHandler(true, axiosError);
+
+      interceptor.intercept(context, handler).subscribe({
+        error: () => {
+          expect(interaction.reply).toHaveBeenCalled();
+          const replyCall = (interaction.reply as jest.Mock).mock.calls[0][0];
+          expect(replyCall.embeds[0].data.description).toBe(
+            'User-friendly error message',
+          );
+          done();
+        },
+      });
+    });
+
+    it('should use generic message for Error without user-friendly message', (done) => {
+      const interaction = createMockInteraction();
+      const context = createMockExecutionContext(interaction);
+      const handler = createMockCallHandler(true, new Error('Internal error'));
+
+      interceptor.intercept(context, handler).subscribe({
+        error: () => {
+          expect(interaction.reply).toHaveBeenCalled();
+          const replyCall = (interaction.reply as jest.Mock).mock.calls[0][0];
+          expect(replyCall.embeds[0].data.description).toBe(
+            'An error occurred while processing your request. Please try again later.',
+          );
+          done();
+        },
+      });
+    });
+
+    it('should use generic message for unknown error types', (done) => {
+      const interaction = createMockInteraction();
+      const context = createMockExecutionContext(interaction);
+      const handler = createMockCallHandler(true, 'String error');
+
+      interceptor.intercept(context, handler).subscribe({
+        error: () => {
+          expect(interaction.reply).toHaveBeenCalled();
+          const replyCall = (interaction.reply as jest.Mock).mock.calls[0][0];
+          expect(replyCall.embeds[0].data.description).toBe(
+            'An unexpected error occurred. Please try again later.',
+          );
+          done();
+        },
+      });
+    });
+
+    it('should handle AxiosError without response data message', (done) => {
+      const interaction = createMockInteraction();
+      const context = createMockExecutionContext(interaction);
+      const axiosError = new AxiosError('API Error');
+      axiosError.response = {
+        data: {},
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: {},
+        config: {} as any,
+      };
+      const handler = createMockCallHandler(true, axiosError);
+
+      interceptor.intercept(context, handler).subscribe({
+        error: () => {
+          expect(interaction.reply).toHaveBeenCalled();
+          const replyCall = (interaction.reply as jest.Mock).mock.calls[0][0];
+          expect(replyCall.embeds[0].data.description).toBe(
+            'An error occurred while processing your request. Please try again later.',
+          );
+          done();
+        },
+      });
+    });
+
+    it('should handle reply errors gracefully', (done) => {
+      const interaction = createMockInteraction();
+      (interaction.reply as jest.Mock).mockRejectedValue(
+        new Error('Reply failed'),
+      );
+      const context = createMockExecutionContext(interaction);
+      const handler = createMockCallHandler(true, new Error('Test error'));
+
+      interceptor.intercept(context, handler).subscribe({
+        error: (error) => {
+          expect(error).toBeInstanceOf(Error);
+          expect(interaction.reply).toHaveBeenCalled();
+          // Error should still be re-thrown
+          done();
+        },
+      });
+    });
+
+    it('should handle followUp errors gracefully', (done) => {
+      const interaction = createMockInteraction({
+        deferred: true,
+        replied: false,
+      });
+      (interaction.followUp as jest.Mock).mockRejectedValue(
+        new Error('FollowUp failed'),
+      );
+      const context = createMockExecutionContext(interaction);
+      const handler = createMockCallHandler(true, new Error('Test error'));
+
+      interceptor.intercept(context, handler).subscribe({
+        error: (error) => {
+          expect(error).toBeInstanceOf(Error);
+          expect(interaction.followUp).toHaveBeenCalled();
+          // Error should still be re-thrown
+          done();
+        },
+      });
+    });
+
+    it('should skip error handling for non-Discord interactions', (done) => {
+      const context = createMockExecutionContext(null);
+      const handler = createMockCallHandler(true, new Error('Test error'));
+
+      interceptor.intercept(context, handler).subscribe({
+        error: (error) => {
+          expect(error).toBeInstanceOf(Error);
+          // Should not try to send Discord messages
+          done();
+        },
+      });
+    });
+
+    it('should re-throw error after handling', (done) => {
+      const interaction = createMockInteraction();
+      const context = createMockExecutionContext(interaction);
+      const originalError = new Error('Original error');
+      const handler = createMockCallHandler(true, originalError);
+
+      interceptor.intercept(context, handler).subscribe({
+        error: (error) => {
+          expect(error).toBe(originalError);
+          expect(interaction.reply).toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+  });
+});

--- a/src/commands/interceptors/error-handling/error-handling.interceptor.ts
+++ b/src/commands/interceptors/error-handling/error-handling.interceptor.ts
@@ -1,0 +1,108 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+  Logger,
+} from '@nestjs/common';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
+
+/**
+ * ErrorHandlingInterceptor - Catches and handles errors from command execution
+ * Logs errors and sends user-friendly error messages to Discord
+ */
+@Injectable()
+export class ErrorHandlingInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(ErrorHandlingInterceptor.name);
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const interaction = this.getInteraction(context);
+
+    return next.handle().pipe(
+      catchError((error: unknown) => {
+        this.logger.error('Command execution error:', error);
+
+        if (interaction && !interaction.replied && !interaction.deferred) {
+          const errorMessage = this.getErrorMessage(error);
+          const embed = new EmbedBuilder()
+            .setTitle('❌ Error')
+            .setDescription(errorMessage)
+            .setColor(0xff0000)
+            .setTimestamp();
+
+          interaction
+            .reply({ embeds: [embed], ephemeral: true })
+            .catch((replyError) => {
+              this.logger.error(
+                'Failed to send error message to user:',
+                replyError,
+              );
+            });
+        } else if (
+          interaction &&
+          (interaction.replied || interaction.deferred)
+        ) {
+          const errorMessage = this.getErrorMessage(error);
+          const embed = new EmbedBuilder()
+            .setTitle('❌ Error')
+            .setDescription(errorMessage)
+            .setColor(0xff0000)
+            .setTimestamp();
+
+          interaction
+            .followUp({ embeds: [embed], ephemeral: true })
+            .catch((followUpError) => {
+              this.logger.error(
+                'Failed to send error follow-up to user:',
+                followUpError,
+              );
+            });
+        }
+
+        // Re-throw error so it can be handled by other error handlers if needed
+        return throwError(() => error);
+      }),
+    );
+  }
+
+  private getInteraction(
+    context: ExecutionContext,
+  ): ChatInputCommandInteraction | null {
+    const args = context.getArgs();
+    if (args && args.length > 0) {
+      const firstArg = args[0] as unknown;
+      if (
+        firstArg &&
+        typeof firstArg === 'object' &&
+        'commandName' in firstArg &&
+        'user' in firstArg
+      ) {
+        return firstArg as ChatInputCommandInteraction;
+      }
+    }
+    return null;
+  }
+
+  private getErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+      // Check if it's an API error with a user-friendly message
+      if ('response' in error && typeof error.response === 'object') {
+        const response = error.response as { data?: { message?: string } };
+        if (response.data?.message) {
+          return response.data.message;
+        }
+      }
+
+      // Use error message if available
+      if (error.message) {
+        // Don't expose internal error messages - use generic message
+        // but log the actual error
+        return 'An error occurred while processing your request. Please try again later.';
+      }
+    }
+
+    return 'An unexpected error occurred. Please try again later.';
+  }
+}

--- a/src/commands/process-trackers.command.spec.ts
+++ b/src/commands/process-trackers.command.spec.ts
@@ -1,0 +1,237 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProcessTrackersCommand } from './process-trackers.command';
+import { ApiService } from '../api/api.service';
+import { ConfigService } from '../config/config.service';
+import { AxiosError } from 'axios';
+import type { SlashCommandContext } from 'necord';
+import { ChatInputCommandInteraction, User } from 'discord.js';
+
+describe('ProcessTrackersCommand', () => {
+  let command: ProcessTrackersCommand;
+  let apiService: jest.Mocked<ApiService>;
+  let configService: jest.Mocked<ConfigService>;
+  let module: TestingModule;
+
+  const createMockInteraction = (
+    userId: string,
+    guildId: string | null = '123456789012345678',
+    options: {
+      deferred?: boolean;
+      replied?: boolean;
+    } = {},
+  ): ChatInputCommandInteraction => {
+    const { deferred = false, replied = false } = options;
+
+    const mockUser = {
+      id: userId,
+    } as User;
+
+    return {
+      user: mockUser,
+      guildId,
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferred,
+      replied,
+    } as unknown as ChatInputCommandInteraction;
+  };
+
+  beforeEach(async () => {
+    const mockApiService = {
+      processTrackers: jest.fn(),
+    };
+
+    const mockConfigService = {
+      getSuperUserId: jest.fn(),
+    };
+
+    module = await Test.createTestingModule({
+      providers: [
+        ProcessTrackersCommand,
+        {
+          provide: ApiService,
+          useValue: mockApiService,
+        },
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
+    }).compile();
+
+    command = module.get<ProcessTrackersCommand>(ProcessTrackersCommand);
+    apiService = module.get(ApiService);
+    configService = module.get(ConfigService);
+
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  it('should be defined', () => {
+    expect(command).toBeDefined();
+  });
+
+  describe('onProcessTrackers', () => {
+    it('should reject unauthorized users', async () => {
+      const interaction = createMockInteraction('111111111111111111');
+      configService.getSuperUserId.mockReturnValue('999999999999999999');
+
+      await command.onProcessTrackers([interaction] as SlashCommandContext);
+
+      expect(configService.getSuperUserId).toHaveBeenCalled();
+      expect(interaction.reply).toHaveBeenCalledWith({
+        content: '❌ You do not have permission to use this command.',
+        ephemeral: true,
+      });
+      expect(apiService.processTrackers).not.toHaveBeenCalled();
+    });
+
+    it('should reject when super user ID is not configured', async () => {
+      const interaction = createMockInteraction('111111111111111111');
+      configService.getSuperUserId.mockReturnValue(undefined);
+
+      await command.onProcessTrackers([interaction] as SlashCommandContext);
+
+      expect(interaction.reply).toHaveBeenCalledWith({
+        content: '❌ You do not have permission to use this command.',
+        ephemeral: true,
+      });
+      expect(apiService.processTrackers).not.toHaveBeenCalled();
+    });
+
+    it('should reject when not in a guild', async () => {
+      const interaction = createMockInteraction('999999999999999999', null);
+      configService.getSuperUserId.mockReturnValue('999999999999999999');
+
+      await command.onProcessTrackers([interaction] as SlashCommandContext);
+
+      expect(interaction.reply).toHaveBeenCalledWith({
+        content: '❌ This command can only be used in a server.',
+        ephemeral: true,
+      });
+      expect(apiService.processTrackers).not.toHaveBeenCalled();
+    });
+
+    it('should successfully process trackers for authorized user', async () => {
+      const interaction = createMockInteraction('999999999999999999');
+      configService.getSuperUserId.mockReturnValue('999999999999999999');
+      apiService.processTrackers.mockResolvedValue({
+        processed: 5,
+        trackers: ['tracker1', 'tracker2'],
+      });
+
+      await command.onProcessTrackers([interaction] as SlashCommandContext);
+
+      expect(interaction.deferReply).toHaveBeenCalledWith({
+        ephemeral: true,
+      });
+      expect(apiService.processTrackers).toHaveBeenCalledWith(
+        '123456789012345678',
+      );
+      expect(interaction.editReply).toHaveBeenCalled();
+      const editCall = (interaction.editReply as jest.Mock).mock.calls[0][0];
+      expect(editCall.embeds[0].data.title).toBe(
+        '✅ Trackers Processing Started',
+      );
+      expect(editCall.embeds[0].data.description).toContain('5');
+    });
+
+    it('should show info message when no trackers are processed', async () => {
+      const interaction = createMockInteraction('999999999999999999');
+      configService.getSuperUserId.mockReturnValue('999999999999999999');
+      apiService.processTrackers.mockResolvedValue({
+        processed: 0,
+        trackers: [],
+      });
+
+      await command.onProcessTrackers([interaction] as SlashCommandContext);
+
+      expect(interaction.editReply).toHaveBeenCalled();
+      const editCall = (interaction.editReply as jest.Mock).mock.calls[0][0];
+      expect(editCall.embeds[0].data.description).toBe(
+        'No pending or stale trackers found to process.',
+      );
+      expect(editCall.embeds[0].data.color).toBe(0xffaa00); // Orange/yellow
+    });
+
+    it('should handle AxiosError with response data message', async () => {
+      const interaction = createMockInteraction('999999999999999999');
+      configService.getSuperUserId.mockReturnValue('999999999999999999');
+
+      const axiosError = new AxiosError('API Error');
+      axiosError.response = {
+        data: {
+          message: 'Guild not found',
+        },
+        status: 404,
+        statusText: 'Not Found',
+        headers: {},
+        config: {} as any,
+      };
+      apiService.processTrackers.mockRejectedValue(axiosError);
+
+      await command.onProcessTrackers([interaction] as SlashCommandContext);
+
+      expect(interaction.editReply).toHaveBeenCalled();
+      const editCall = (interaction.editReply as jest.Mock).mock.calls[0][0];
+      expect(editCall.embeds[0].data.title).toBe('❌ Process Trackers Failed');
+      expect(editCall.embeds[0].data.description).toBe('Guild not found');
+    });
+
+    it('should handle AxiosError without response data message', async () => {
+      const interaction = createMockInteraction('999999999999999999');
+      configService.getSuperUserId.mockReturnValue('999999999999999999');
+
+      const axiosError = new AxiosError('API Error');
+      axiosError.response = {
+        data: {},
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: {},
+        config: {} as any,
+      };
+      apiService.processTrackers.mockRejectedValue(axiosError);
+
+      await command.onProcessTrackers([interaction] as SlashCommandContext);
+
+      expect(interaction.editReply).toHaveBeenCalled();
+      const editCall = (interaction.editReply as jest.Mock).mock.calls[0][0];
+      expect(editCall.embeds[0].data.description).toBe(
+        'An error occurred while processing trackers. Please try again.',
+      );
+    });
+
+    it('should handle generic Error with message', async () => {
+      const interaction = createMockInteraction('999999999999999999');
+      configService.getSuperUserId.mockReturnValue('999999999999999999');
+
+      const error = new Error('Network timeout');
+      apiService.processTrackers.mockRejectedValue(error);
+
+      await command.onProcessTrackers([interaction] as SlashCommandContext);
+
+      expect(interaction.editReply).toHaveBeenCalled();
+      const editCall = (interaction.editReply as jest.Mock).mock.calls[0][0];
+      expect(editCall.embeds[0].data.description).toBe('Network timeout');
+    });
+
+    it('should handle unknown error type', async () => {
+      const interaction = createMockInteraction('999999999999999999');
+      configService.getSuperUserId.mockReturnValue('999999999999999999');
+
+      apiService.processTrackers.mockRejectedValue('String error');
+
+      await command.onProcessTrackers([interaction] as SlashCommandContext);
+
+      expect(interaction.editReply).toHaveBeenCalled();
+      const editCall = (interaction.editReply as jest.Mock).mock.calls[0][0];
+      expect(editCall.embeds[0].data.description).toBe(
+        'An error occurred while processing trackers. Please try again.',
+      );
+    });
+  });
+});

--- a/src/commands/process-trackers.command.ts
+++ b/src/commands/process-trackers.command.ts
@@ -1,0 +1,96 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SlashCommand, Context } from 'necord';
+import type { SlashCommandContext } from 'necord';
+import { EmbedBuilder } from 'discord.js';
+import { ApiService } from '../api/api.service';
+import { ConfigService } from '../config/config.service';
+import { AxiosError } from 'axios';
+
+/**
+ * ProcessTrackersCommand - Single Responsibility: Handle /process-trackers command
+ *
+ * Triggers the API to process/scrape tracker information for the current guild.
+ * Only callable by the super user.
+ */
+@Injectable()
+export class ProcessTrackersCommand {
+  private readonly logger = new Logger(ProcessTrackersCommand.name);
+
+  constructor(
+    private readonly apiService: ApiService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  @SlashCommand({
+    name: 'process-trackers',
+    description:
+      'Trigger tracker data processing for this server (super user only)',
+  })
+  public async onProcessTrackers(
+    @Context() [interaction]: SlashCommandContext,
+  ): Promise<void> {
+    const superUserId = this.configService.getSuperUserId();
+    const userId = interaction.user.id;
+
+    if (!superUserId || userId !== superUserId) {
+      this.logger.warn(
+        `Unauthorized process-trackers attempt by user ${userId}`,
+      );
+      await interaction.reply({
+        content: '❌ You do not have permission to use this command.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    if (!interaction.guildId) {
+      await interaction.reply({
+        content: '❌ This command can only be used in a server.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    await interaction.deferReply({ ephemeral: true });
+
+    try {
+      const result = await this.apiService.processTrackers(interaction.guildId);
+
+      const embed = new EmbedBuilder()
+        .setTitle('✅ Trackers Processing Started')
+        .setDescription(
+          `Successfully queued processing for **${result.processed}** tracker(s).`,
+        )
+        .setColor(0x00ff00)
+        .setTimestamp();
+
+      if (result.processed === 0) {
+        embed.setDescription('No pending or stale trackers found to process.');
+        embed.setColor(0xffaa00); // Orange/yellow for info
+      }
+
+      await interaction.editReply({ embeds: [embed] });
+    } catch (error: unknown) {
+      this.logger.error('Failed to process trackers:', error);
+
+      let errorMessage =
+        'An error occurred while processing trackers. Please try again.';
+      if (error instanceof AxiosError && error.response?.data) {
+        const data = error.response.data as { message?: string };
+        if (data.message) {
+          errorMessage = data.message;
+        }
+      } else if (error instanceof Error && error.message) {
+        errorMessage = error.message;
+      }
+
+      const embed = new EmbedBuilder()
+        .setTitle('❌ Process Trackers Failed')
+        .setDescription(errorMessage)
+        .setColor(0xff0000)
+        .setTimestamp();
+
+      await interaction.editReply({ embeds: [embed] });
+    }
+  }
+}

--- a/src/commands/register.command.spec.ts
+++ b/src/commands/register.command.spec.ts
@@ -1,0 +1,435 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RegisterCommand } from './register.command';
+import { ApiService } from '../api/api.service';
+import { AxiosError } from 'axios';
+import type { SlashCommandContext } from 'necord';
+import { ChatInputCommandInteraction, User } from 'discord.js';
+
+describe('RegisterCommand', () => {
+  let command: RegisterCommand;
+  let apiService: jest.Mocked<ApiService>;
+  let module: TestingModule;
+
+  const createMockInteraction = (
+    userId: string,
+    username: string,
+    urls: {
+      url1: string;
+      url2?: string | null;
+      url3?: string | null;
+      url4?: string | null;
+    },
+    options: {
+      deferred?: boolean;
+      replied?: boolean;
+      channelId?: string | null;
+      globalName?: string | null;
+      avatar?: string | null;
+    } = {},
+  ): ChatInputCommandInteraction => {
+    const {
+      deferred = false,
+      replied = false,
+      channelId = '123456789012345678',
+      globalName = null,
+      avatar = null,
+    } = options;
+
+    const mockUser = {
+      id: userId,
+      username,
+      globalName,
+      avatar,
+    } as User;
+
+    return {
+      user: mockUser,
+      options: {
+        getString: jest.fn().mockImplementation((name: string) => {
+          if (name === 'tracker_url_1') return urls.url1;
+          if (name === 'tracker_url_2') return urls.url2 ?? null;
+          if (name === 'tracker_url_3') return urls.url3 ?? null;
+          if (name === 'tracker_url_4') return urls.url4 ?? null;
+          return null;
+        }),
+      },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferred,
+      replied,
+      channelId,
+      token: 'test-token',
+    } as unknown as ChatInputCommandInteraction;
+  };
+
+  beforeEach(async () => {
+    const mockApiService = {
+      registerTrackers: jest.fn(),
+    };
+
+    module = await Test.createTestingModule({
+      providers: [
+        RegisterCommand,
+        {
+          provide: ApiService,
+          useValue: mockApiService,
+        },
+      ],
+    }).compile();
+
+    command = module.get<RegisterCommand>(RegisterCommand);
+    apiService = module.get(ApiService);
+
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  it('should be defined', () => {
+    expect(command).toBeDefined();
+  });
+
+  describe('onRegister', () => {
+    it('should successfully register a single tracker', async () => {
+      const interaction = createMockInteraction(
+        '111111111111111111',
+        'testuser',
+        {
+          url1: 'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+        },
+      );
+
+      const mockTrackersResponse = [
+        {
+          url: 'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+          platform: 'steam',
+          username: 'testuser',
+          scrapingStatus: 'PENDING',
+        },
+      ];
+
+      apiService.registerTrackers.mockResolvedValue(mockTrackersResponse);
+
+      await command.onRegister([interaction] as SlashCommandContext);
+
+      expect(interaction.deferReply).toHaveBeenCalledWith({
+        ephemeral: true,
+      });
+      expect(apiService.registerTrackers).toHaveBeenCalledWith(
+        '111111111111111111',
+        [
+          'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+        ],
+        {
+          username: 'testuser',
+          globalName: undefined,
+          avatar: undefined,
+        },
+        '123456789012345678',
+        'test-token',
+      );
+      expect(interaction.editReply).toHaveBeenCalled();
+      const editCall = (interaction.editReply as jest.Mock).mock.calls[0][0];
+      expect(editCall.embeds[0].data.title).toBe(
+        '✅ Trackers Registered Successfully',
+      );
+    });
+
+    it('should successfully register multiple trackers', async () => {
+      const interaction = createMockInteraction(
+        '111111111111111111',
+        'testuser',
+        {
+          url1: 'https://rocketleague.tracker.network/rocket-league/profile/steam/user1/overview',
+          url2: 'https://rocketleague.tracker.network/rocket-league/profile/steam/user2/overview',
+          url3: 'https://rocketleague.tracker.network/rocket-league/profile/steam/user3/overview',
+          url4: 'https://rocketleague.tracker.network/rocket-league/profile/steam/user4/overview',
+        },
+      );
+
+      const mockTrackersResponse = [
+        {
+          url: 'https://rocketleague.tracker.network/rocket-league/profile/steam/user1/overview',
+          platform: 'steam',
+          username: 'user1',
+          scrapingStatus: 'PENDING',
+        },
+        {
+          url: 'https://rocketleague.tracker.network/rocket-league/profile/steam/user2/overview',
+          platform: 'steam',
+          username: 'user2',
+          scrapingStatus: 'PENDING',
+        },
+        {
+          url: 'https://rocketleague.tracker.network/rocket-league/profile/steam/user3/overview',
+          platform: 'steam',
+          username: 'user3',
+          scrapingStatus: 'PENDING',
+        },
+        {
+          url: 'https://rocketleague.tracker.network/rocket-league/profile/steam/user4/overview',
+          platform: 'steam',
+          username: 'user4',
+          scrapingStatus: 'PENDING',
+        },
+      ];
+
+      apiService.registerTrackers.mockResolvedValue(mockTrackersResponse);
+
+      await command.onRegister([interaction] as SlashCommandContext);
+
+      expect(apiService.registerTrackers).toHaveBeenCalledWith(
+        '111111111111111111',
+        expect.arrayContaining([
+          'https://rocketleague.tracker.network/rocket-league/profile/steam/user1/overview',
+          'https://rocketleague.tracker.network/rocket-league/profile/steam/user2/overview',
+          'https://rocketleague.tracker.network/rocket-league/profile/steam/user3/overview',
+          'https://rocketleague.tracker.network/rocket-league/profile/steam/user4/overview',
+        ]),
+        expect.any(Object),
+        '123456789012345678',
+        'test-token',
+      );
+      const editCall = (interaction.editReply as jest.Mock).mock.calls[0][0];
+      expect(editCall.embeds[0].data.description).toContain('4 tracker(s)');
+    });
+
+    it('should filter out empty and whitespace-only URLs', async () => {
+      const interaction = createMockInteraction(
+        '111111111111111111',
+        'testuser',
+        {
+          url1: 'https://rocketleague.tracker.network/rocket-league/profile/steam/user1/overview',
+          url2: '',
+          url3: '   ',
+          url4: null,
+        },
+      );
+
+      const mockTrackersResponse = [
+        {
+          url: 'https://rocketleague.tracker.network/rocket-league/profile/steam/user1/overview',
+          platform: 'steam',
+          username: 'user1',
+          scrapingStatus: 'PENDING',
+        },
+      ];
+
+      apiService.registerTrackers.mockResolvedValue(mockTrackersResponse);
+
+      await command.onRegister([interaction] as SlashCommandContext);
+
+      expect(apiService.registerTrackers).toHaveBeenCalledWith(
+        '111111111111111111',
+        [
+          'https://rocketleague.tracker.network/rocket-league/profile/steam/user1/overview',
+        ],
+        expect.any(Object),
+        '123456789012345678',
+        'test-token',
+      );
+    });
+
+    it('should include user globalName and avatar when available', async () => {
+      const interaction = createMockInteraction(
+        '111111111111111111',
+        'testuser',
+        {
+          url1: 'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+        },
+        {
+          globalName: 'Test Global Name',
+          avatar: 'avatar-hash',
+        },
+      );
+
+      const mockTrackersResponse = [
+        {
+          url: 'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+          platform: 'steam',
+          username: 'testuser',
+          scrapingStatus: 'PENDING',
+        },
+      ];
+
+      apiService.registerTrackers.mockResolvedValue(mockTrackersResponse);
+
+      await command.onRegister([interaction] as SlashCommandContext);
+
+      expect(apiService.registerTrackers).toHaveBeenCalledWith(
+        '111111111111111111',
+        expect.any(Array),
+        {
+          username: 'testuser',
+          globalName: 'Test Global Name',
+          avatar: 'avatar-hash',
+        },
+        '123456789012345678',
+        'test-token',
+      );
+    });
+
+    it('should handle tracker responses with missing optional fields', async () => {
+      const interaction = createMockInteraction(
+        '111111111111111111',
+        'testuser',
+        {
+          url1: 'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+        },
+      );
+
+      const mockTrackersResponse = [
+        {
+          url: undefined,
+          platform: undefined,
+          username: undefined,
+          scrapingStatus: undefined,
+        },
+      ];
+
+      apiService.registerTrackers.mockResolvedValue(mockTrackersResponse);
+
+      await command.onRegister([interaction] as SlashCommandContext);
+
+      expect(interaction.editReply).toHaveBeenCalled();
+      const editCall = (interaction.editReply as jest.Mock).mock.calls[0][0];
+      expect(editCall.embeds[0].data.fields).toBeDefined();
+    });
+
+    it('should handle AxiosError with response data message', async () => {
+      const interaction = createMockInteraction(
+        '111111111111111111',
+        'testuser',
+        {
+          url1: 'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+        },
+      );
+
+      const axiosError = new AxiosError('API Error');
+      axiosError.response = {
+        data: {
+          message: 'Invalid tracker URL format',
+        },
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config: {} as any,
+      };
+      apiService.registerTrackers.mockRejectedValue(axiosError);
+
+      await command.onRegister([interaction] as SlashCommandContext);
+
+      expect(interaction.deferReply).toHaveBeenCalled();
+      expect(interaction.editReply).toHaveBeenCalled();
+      const editCall = (interaction.editReply as jest.Mock).mock.calls[0][0];
+      expect(editCall.embeds[0].data.title).toBe('❌ Registration Failed');
+      expect(editCall.embeds[0].data.description).toBe(
+        'Invalid tracker URL format',
+      );
+    });
+
+    it('should handle AxiosError without response data message', async () => {
+      const interaction = createMockInteraction(
+        '111111111111111111',
+        'testuser',
+        {
+          url1: 'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+        },
+      );
+
+      const axiosError = new AxiosError('API Error');
+      axiosError.response = {
+        data: {},
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: {},
+        config: {} as any,
+      };
+      apiService.registerTrackers.mockRejectedValue(axiosError);
+
+      await command.onRegister([interaction] as SlashCommandContext);
+
+      expect(interaction.editReply).toHaveBeenCalled();
+      const editCall = (interaction.editReply as jest.Mock).mock.calls[0][0];
+      expect(editCall.embeds[0].data.description).toBe(
+        'An error occurred during registration. Please try again.',
+      );
+    });
+
+    it('should handle generic Error with message', async () => {
+      const interaction = createMockInteraction(
+        '111111111111111111',
+        'testuser',
+        {
+          url1: 'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+        },
+      );
+
+      const error = new Error('Network timeout');
+      apiService.registerTrackers.mockRejectedValue(error);
+
+      await command.onRegister([interaction] as SlashCommandContext);
+
+      expect(interaction.editReply).toHaveBeenCalled();
+      const editCall = (interaction.editReply as jest.Mock).mock.calls[0][0];
+      expect(editCall.embeds[0].data.description).toBe('Network timeout');
+    });
+
+    it('should handle unknown error type', async () => {
+      const interaction = createMockInteraction(
+        '111111111111111111',
+        'testuser',
+        {
+          url1: 'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+        },
+      );
+
+      apiService.registerTrackers.mockRejectedValue('String error');
+
+      await command.onRegister([interaction] as SlashCommandContext);
+
+      expect(interaction.editReply).toHaveBeenCalled();
+      const editCall = (interaction.editReply as jest.Mock).mock.calls[0][0];
+      expect(editCall.embeds[0].data.description).toBe(
+        'An error occurred during registration. Please try again.',
+      );
+    });
+
+    it('should handle null channelId', async () => {
+      const interaction = createMockInteraction(
+        '111111111111111111',
+        'testuser',
+        {
+          url1: 'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+        },
+        {
+          channelId: null,
+        },
+      );
+
+      const mockTrackersResponse = [
+        {
+          url: 'https://rocketleague.tracker.network/rocket-league/profile/steam/testuser/overview',
+          platform: 'steam',
+          username: 'testuser',
+          scrapingStatus: 'PENDING',
+        },
+      ];
+
+      apiService.registerTrackers.mockResolvedValue(mockTrackersResponse);
+
+      await command.onRegister([interaction] as SlashCommandContext);
+
+      expect(apiService.registerTrackers).toHaveBeenCalledWith(
+        '111111111111111111',
+        expect.any(Array),
+        expect.any(Object),
+        null,
+        'test-token',
+      );
+    });
+  });
+});

--- a/src/commands/register.command.ts
+++ b/src/commands/register.command.ts
@@ -1,0 +1,143 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SlashCommand, Context } from 'necord';
+import type { SlashCommandContext } from 'necord';
+import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
+import { ApiService } from '../api/api.service';
+import { AxiosError } from 'axios';
+
+/**
+ * RegisterCommand - Single Responsibility: Handle /register command
+ *
+ * Allows users to register up to 4 Rocket League tracker URLs.
+ * The tracker data will be automatically collected via scraping.
+ */
+
+interface TrackerResponse {
+  url?: string;
+  platform?: string;
+  username?: string;
+  scrapingStatus?: string;
+}
+
+@Injectable()
+export class RegisterCommand {
+  private readonly logger = new Logger(RegisterCommand.name);
+
+  constructor(private readonly apiService: ApiService) {}
+
+  @SlashCommand(
+    new SlashCommandBuilder()
+      .setName('register')
+      .setDescription('Register up to 4 Rocket League tracker URLs')
+      .addStringOption((option) =>
+        option
+          .setName('tracker_url_1')
+          .setDescription('Your first tracker URL (required)')
+          .setRequired(true),
+      )
+      .addStringOption((option) =>
+        option
+          .setName('tracker_url_2')
+          .setDescription('Your second tracker URL (optional)')
+          .setRequired(false),
+      )
+      .addStringOption((option) =>
+        option
+          .setName('tracker_url_3')
+          .setDescription('Your third tracker URL (optional)')
+          .setRequired(false),
+      )
+      .addStringOption((option) =>
+        option
+          .setName('tracker_url_4')
+          .setDescription('Your fourth tracker URL (optional)')
+          .setRequired(false),
+      )
+      .toJSON(),
+  )
+  public async onRegister(
+    @Context() [interaction]: SlashCommandContext,
+  ): Promise<void> {
+    const urls = [
+      interaction.options.getString('tracker_url_1', true),
+      interaction.options.getString('tracker_url_2'),
+      interaction.options.getString('tracker_url_3'),
+      interaction.options.getString('tracker_url_4'),
+    ].filter((url): url is string => url !== null && url.trim() !== '');
+
+    const userId = interaction.user.id;
+    const userData = {
+      username: interaction.user.username,
+      globalName: interaction.user.globalName || undefined,
+      avatar: interaction.user.avatar || undefined,
+    };
+
+    await interaction.deferReply({ ephemeral: true });
+
+    try {
+      // Capture channel context for ephemeral follow-up messages
+      const channelId = interaction.channelId;
+      const interactionToken = interaction.token;
+
+      const trackers = (await this.apiService.registerTrackers(
+        userId,
+        urls,
+        userData,
+        channelId,
+        interactionToken,
+      )) as TrackerResponse[];
+
+      const embed = new EmbedBuilder()
+        .setTitle('✅ Trackers Registered Successfully')
+        .setDescription(
+          `Successfully registered ${trackers.length} tracker(s). Data is being collected in the background.`,
+        )
+        .setColor(0x00ff00)
+        .addFields(
+          trackers.map((tracker: TrackerResponse, index: number) => ({
+            name: `Tracker ${index + 1}`,
+            value: [
+              `**URL:** ${tracker.url || 'N/A'}`,
+              `**Platform:** ${tracker.platform || 'Unknown'}`,
+              `**Username:** ${tracker.username || 'Unknown'}`,
+              `**Status:** ${tracker.scrapingStatus || 'PENDING'}`,
+            ].join('\n'),
+            inline: false,
+          })),
+        )
+        .setFooter({
+          text: 'You can check your tracker status in the web dashboard.',
+        })
+        .setTimestamp();
+
+      await interaction.editReply({ embeds: [embed] });
+    } catch (error: unknown) {
+      this.logger.error('Failed to register trackers:', error);
+
+      let errorMessage =
+        'An error occurred during registration. Please try again.';
+      if (error instanceof AxiosError && error.response?.data) {
+        const data = error.response.data as { message?: string };
+        if (data.message) {
+          errorMessage = data.message;
+        }
+      } else if (error instanceof Error && error.message) {
+        errorMessage = error.message;
+      }
+
+      const embed = new EmbedBuilder()
+        .setTitle('❌ Registration Failed')
+        .setDescription(errorMessage)
+        .setColor(0xff0000)
+        .addFields({
+          name: 'Tip',
+          value:
+            'Make sure your URLs are in the format: https://rocketleague.tracker.network/rocket-league/profile/{platform}/{username}/overview',
+          inline: false,
+        })
+        .setTimestamp();
+
+      await interaction.editReply({ embeds: [embed] });
+    }
+  }
+}

--- a/src/config/config.schema.ts
+++ b/src/config/config.schema.ts
@@ -15,6 +15,10 @@ export const configSchema = z.object({
   DASHBOARD_URL: z
     .union([z.string().url('DASHBOARD_URL must be a valid URL'), z.literal('')])
     .optional(),
+  SUPER_USER_ID: z
+    .string()
+    .regex(/^\d{17,19}$/, 'SUPER_USER_ID must be a valid Discord ID')
+    .optional(),
   NODE_ENV: z
     .enum(['development', 'production', 'test'])
     .default('development'),

--- a/src/config/config.service.spec.ts
+++ b/src/config/config.service.spec.ts
@@ -419,4 +419,34 @@ describe('ConfigService', () => {
       expect(result).toBe(9000);
     });
   });
+
+  describe('getSuperUserId', () => {
+    it('should return super user ID when configured', () => {
+      const superUserId = '123456789012345678';
+      nestConfigService.get.mockReturnValue(superUserId);
+
+      const result = service.getSuperUserId();
+
+      expect(result).toBe(superUserId);
+      expect(nestConfigService.get).toHaveBeenCalledWith('SUPER_USER_ID', {
+        infer: true,
+      });
+    });
+
+    it('should return undefined when super user ID is not configured', () => {
+      nestConfigService.get.mockReturnValue(undefined);
+
+      const result = service.getSuperUserId();
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when super user ID is empty string', () => {
+      nestConfigService.get.mockReturnValue('');
+
+      const result = service.getSuperUserId();
+
+      expect(result).toBeUndefined();
+    });
+  });
 });

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -71,6 +71,13 @@ export class ConfigService {
     return value === '' ? undefined : value;
   }
 
+  getSuperUserId(): string | undefined {
+    const value = this.nestConfigService.get<string>('SUPER_USER_ID', {
+      infer: true,
+    });
+    return value === '' ? undefined : value;
+  }
+
   getNodeEnv(): 'development' | 'production' | 'test' {
     const nodeEnv = this.nestConfigService.get<
       'development' | 'production' | 'test'


### PR DESCRIPTION
Add comprehensive Discord slash command system with global interceptors:

- Add /register command for initial tracker registration (up to 4 trackers)
- Add /add-tracker command for additional tracker registration
- Add /config command for dashboard configuration access
- Add /help command for command listing
- Add /process-trackers command for super user tracker processing

Implement global interceptors:
- CooldownInterceptor: Prevents command spam with per-user, per-command cooldowns
- ErrorHandlingInterceptor: Catches and transforms errors into user-friendly Discord messages

Add CommandsModule with APP_INTERCEPTOR registration for global interceptor application.
All commands include comprehensive test coverage with edge case handling.