### PR TITLE
[Phase 8] Permission System Migration

### DIFF
--- a/src/api/api.module.spec.ts
+++ b/src/api/api.module.spec.ts
@@ -1,5 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ApiModule } from './api.module';
+import { ApiService } from './api.service';
+import { ApiHealthService } from './api-health.service';
+import { ApiHealthGuard } from './api-health.guard';
+import { HttpModule } from '@nestjs/axios';
 
 describe('ApiModule', () => {
   let module: TestingModule;
@@ -11,14 +15,13 @@ describe('ApiModule', () => {
       ...originalEnv,
       DISCORD_TOKEN: 'test-token',
       BOT_API_KEY: 'test-api-key',
+      API_BASE_URL: 'http://localhost:3000',
     };
 
     try {
       module = await Test.createTestingModule({
         imports: [ApiModule],
       }).compile();
-
-      expect(module).toBeDefined();
     } finally {
       process.env = originalEnv;
     }
@@ -30,5 +33,32 @@ describe('ApiModule', () => {
 
   it('should compile successfully', () => {
     expect(module).toBeDefined();
+  });
+
+  it('should resolve ApiService via DI', () => {
+    const service = module.get<ApiService>(ApiService);
+
+    expect(service).toBeDefined();
+    expect(service).toBeInstanceOf(ApiService);
+  });
+
+  it('should resolve ApiHealthService via DI', () => {
+    const service = module.get<ApiHealthService>(ApiHealthService);
+
+    expect(service).toBeDefined();
+    expect(service).toBeInstanceOf(ApiHealthService);
+  });
+
+  it('should resolve ApiHealthGuard via DI', () => {
+    const guard = module.get<ApiHealthGuard>(ApiHealthGuard);
+
+    expect(guard).toBeDefined();
+    expect(guard).toBeInstanceOf(ApiHealthGuard);
+  });
+
+  it('should export HttpModule', () => {
+    const httpModule = module.get(HttpModule);
+
+    expect(httpModule).toBeDefined();
   });
 });

--- a/src/app.service.spec.ts
+++ b/src/app.service.spec.ts
@@ -1,0 +1,31 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppService } from './app.service';
+
+describe('AppService', () => {
+  let service: AppService;
+  let module: TestingModule;
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      providers: [AppService],
+    }).compile();
+
+    service = module.get<AppService>(AppService);
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getHello', () => {
+    it('should return "Hello World!"', () => {
+      const result = service.getHello();
+
+      expect(result).toBe('Hello World!');
+    });
+  });
+});

--- a/src/app/app.module.spec.ts
+++ b/src/app/app.module.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppModule } from './app.module';
+import { AppController } from '../app.controller';
+import { AppService } from '../app.service';
 
 describe('AppModule', () => {
   let module: TestingModule;
@@ -17,8 +19,6 @@ describe('AppModule', () => {
       module = await Test.createTestingModule({
         imports: [AppModule],
       }).compile();
-
-      expect(module).toBeDefined();
     } finally {
       process.env = originalEnv;
     }
@@ -30,5 +30,25 @@ describe('AppModule', () => {
 
   it('should compile successfully', () => {
     expect(module).toBeDefined();
+  });
+
+  it('should resolve AppController via DI', () => {
+    const controller = module.get<AppController>(AppController);
+
+    expect(controller).toBeDefined();
+    expect(controller).toBeInstanceOf(AppController);
+  });
+
+  it('should resolve AppService via DI', () => {
+    const service = module.get<AppService>(AppService);
+
+    expect(service).toBeDefined();
+    expect(service).toBeInstanceOf(AppService);
+  });
+
+  it('should inject AppService into AppController', () => {
+    const controller = module.get<AppController>(AppController);
+
+    expect(controller).toBeDefined();
   });
 });

--- a/src/commands/commands.module.ts
+++ b/src/commands/commands.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
-import { APP_INTERCEPTOR } from '@nestjs/core';
+import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { ApiModule } from '../api/api.module';
 import { ConfigModule } from '../config/config.module';
+import { PermissionsModule } from '../permissions/permissions.module';
+import { PermissionGuard } from '../permissions/permission/permission.guard';
 import { ConfigCommand } from './config.command';
 import { HelpCommand } from './help.command';
 import { RegisterCommand } from './register.command';
@@ -11,13 +13,19 @@ import { CooldownInterceptor } from './interceptors/cooldown/cooldown.intercepto
 import { ErrorHandlingInterceptor } from './interceptors/error-handling/error-handling.interceptor';
 
 @Module({
-  imports: [ApiModule, ConfigModule],
+  imports: [ApiModule, ConfigModule, PermissionsModule],
   providers: [
     ConfigCommand,
     HelpCommand,
     RegisterCommand,
     AddTrackerCommand,
     ProcessTrackersCommand,
+    // Apply guard globally - checks permissions before interceptors
+    // Guards execute before interceptors in NestJS
+    {
+      provide: APP_GUARD,
+      useClass: PermissionGuard,
+    },
     // Apply interceptors globally - they check for Discord interactions and skip if not found
     // Note: Interceptors registered via APP_INTERCEPTOR don't need to be in providers array
     // unless they need to be injected elsewhere. NestJS will instantiate them automatically.

--- a/src/commands/process-trackers.command.spec.ts
+++ b/src/commands/process-trackers.command.spec.ts
@@ -76,45 +76,9 @@ describe('ProcessTrackersCommand', () => {
   });
 
   describe('onProcessTrackers', () => {
-    it('should reject unauthorized users', async () => {
-      const interaction = createMockInteraction('111111111111111111');
-      configService.getSuperUserId.mockReturnValue('999999999999999999');
-
-      await command.onProcessTrackers([interaction] as SlashCommandContext);
-
-      expect(configService.getSuperUserId).toHaveBeenCalled();
-      expect(interaction.reply).toHaveBeenCalledWith({
-        content: '❌ You do not have permission to use this command.',
-        ephemeral: true,
-      });
-      expect(apiService.processTrackers).not.toHaveBeenCalled();
-    });
-
-    it('should reject when super user ID is not configured', async () => {
-      const interaction = createMockInteraction('111111111111111111');
-      configService.getSuperUserId.mockReturnValue(undefined);
-
-      await command.onProcessTrackers([interaction] as SlashCommandContext);
-
-      expect(interaction.reply).toHaveBeenCalledWith({
-        content: '❌ You do not have permission to use this command.',
-        ephemeral: true,
-      });
-      expect(apiService.processTrackers).not.toHaveBeenCalled();
-    });
-
-    it('should reject when not in a guild', async () => {
-      const interaction = createMockInteraction('999999999999999999', null);
-      configService.getSuperUserId.mockReturnValue('999999999999999999');
-
-      await command.onProcessTrackers([interaction] as SlashCommandContext);
-
-      expect(interaction.reply).toHaveBeenCalledWith({
-        content: '❌ This command can only be used in a server.',
-        ephemeral: true,
-      });
-      expect(apiService.processTrackers).not.toHaveBeenCalled();
-    });
+    // Note: Permission checks (super user, guild) are handled by PermissionGuard
+    // which runs before this command is executed. These tests assume the guard
+    // has already authorized the user.
 
     it('should successfully process trackers for authorized user', async () => {
       const interaction = createMockInteraction('999999999999999999');

--- a/src/commands/process-trackers.command.ts
+++ b/src/commands/process-trackers.command.ts
@@ -29,27 +29,9 @@ export class ProcessTrackersCommand {
   public async onProcessTrackers(
     @Context() [interaction]: SlashCommandContext,
   ): Promise<void> {
-    const superUserId = this.configService.getSuperUserId();
-    const userId = interaction.user.id;
-
-    if (!superUserId || userId !== superUserId) {
-      this.logger.warn(
-        `Unauthorized process-trackers attempt by user ${userId}`,
-      );
-      await interaction.reply({
-        content: '❌ You do not have permission to use this command.',
-        ephemeral: true,
-      });
-      return;
-    }
-
-    if (!interaction.guildId) {
-      await interaction.reply({
-        content: '❌ This command can only be used in a server.',
-        ephemeral: true,
-      });
-      return;
-    }
+    // Permission check is handled by PermissionGuard
+    // Guild check is handled by PermissionGuard via metadata (requiresGuild: true)
+    // Super user check is handled by PermissionGuard via metadata (requiresSuperUser: true)
 
     await interaction.deferReply({ ephemeral: true });
 

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -3,6 +3,7 @@ import { Logger } from '@nestjs/common';
 import { INestApplication } from '@nestjs/common';
 import { ApiHealthService } from './api/api-health.service';
 import { ConfigService } from './config/config.service';
+import { bootstrap } from './main';
 
 jest.mock('@nestjs/core', () => ({
   NestFactory: {
@@ -13,9 +14,6 @@ jest.mock('@nestjs/core', () => ({
 jest.mock('./app/app.module', () => ({
   AppModule: class AppModule {},
 }));
-
-// Import bootstrap after mocks are set up
-import { bootstrap } from './main';
 
 describe('main bootstrap', () => {
   let mockApp: jest.Mocked<INestApplication>;

--- a/src/permissions/permission-logger/permission-logger.service.spec.ts
+++ b/src/permissions/permission-logger/permission-logger.service.spec.ts
@@ -1,0 +1,194 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PermissionLoggerService } from './permission-logger.service';
+import { ChatInputCommandInteraction } from 'discord.js';
+import { ValidationResult } from '../permission-validator/permission-validator.service';
+import { PermissionMetadata } from '../permission-metadata.interface';
+
+describe('PermissionLoggerService', () => {
+  let service: PermissionLoggerService;
+  let module: TestingModule;
+
+  const mockInteraction = {
+    user: { id: '123456789012345678' },
+    guildId: '987654321098765432',
+    channelId: '111111111111111111',
+    commandName: 'test-command',
+  } as unknown as ChatInputCommandInteraction;
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      providers: [PermissionLoggerService],
+    }).compile();
+
+    service = module.get<PermissionLoggerService>(PermissionLoggerService);
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('logCommandExecution', () => {
+    it('should log command execution with allowed result', () => {
+      const result: ValidationResult = { allowed: true };
+      const metadata: PermissionMetadata = { category: 'admin' };
+
+      const logSpy = jest.spyOn(service['logger'], 'log');
+
+      service.logCommandExecution(mockInteraction, result, metadata);
+
+      expect(logSpy).toHaveBeenCalledWith('Command execution: test-command', {
+        userId: '123456789012345678',
+        guildId: '987654321098765432',
+        channelId: '111111111111111111',
+        allowed: true,
+        category: 'admin',
+      });
+    });
+
+    it('should log command execution with denied result', () => {
+      const result: ValidationResult = {
+        allowed: false,
+        reason: 'Permission denied',
+      };
+      const metadata: PermissionMetadata = { category: 'admin' };
+
+      const logSpy = jest.spyOn(service['logger'], 'log');
+
+      service.logCommandExecution(mockInteraction, result, metadata);
+
+      expect(logSpy).toHaveBeenCalledWith('Command execution: test-command', {
+        userId: '123456789012345678',
+        guildId: '987654321098765432',
+        channelId: '111111111111111111',
+        allowed: false,
+        category: 'admin',
+      });
+    });
+
+    it('should use default category when metadata category is not provided', () => {
+      const result: ValidationResult = { allowed: true };
+
+      const logSpy = jest.spyOn(service['logger'], 'log');
+
+      service.logCommandExecution(mockInteraction, result);
+
+      expect(logSpy).toHaveBeenCalledWith('Command execution: test-command', {
+        userId: '123456789012345678',
+        guildId: '987654321098765432',
+        channelId: '111111111111111111',
+        allowed: true,
+        category: 'public',
+      });
+    });
+
+    it('should handle DM interactions', () => {
+      const dmInteraction = {
+        ...mockInteraction,
+        guildId: null,
+        channelId: null,
+      } as unknown as ChatInputCommandInteraction;
+      const result: ValidationResult = { allowed: true };
+
+      const logSpy = jest.spyOn(service['logger'], 'log');
+
+      service.logCommandExecution(dmInteraction, result);
+
+      expect(logSpy).toHaveBeenCalledWith('Command execution: test-command', {
+        userId: '123456789012345678',
+        guildId: 'DM',
+        channelId: 'unknown',
+        allowed: true,
+        category: 'public',
+      });
+    });
+  });
+
+  describe('logPermissionDenial', () => {
+    it('should log permission denial with reason', () => {
+      const reason = 'You do not have permission to use this command';
+
+      const warnSpy = jest.spyOn(service['logger'], 'warn');
+
+      service.logPermissionDenial(mockInteraction, reason);
+
+      expect(warnSpy).toHaveBeenCalledWith('Permission denied', {
+        userId: '123456789012345678',
+        guildId: '987654321098765432',
+        commandName: 'test-command',
+        reason,
+      });
+    });
+
+    it('should handle DM interactions', () => {
+      const dmInteraction = {
+        ...mockInteraction,
+        guildId: null,
+      } as unknown as ChatInputCommandInteraction;
+      const reason = 'Permission denied';
+
+      const warnSpy = jest.spyOn(service['logger'], 'warn');
+
+      service.logPermissionDenial(dmInteraction, reason);
+
+      expect(warnSpy).toHaveBeenCalledWith('Permission denied', {
+        userId: '123456789012345678',
+        guildId: 'DM',
+        commandName: 'test-command',
+        reason,
+      });
+    });
+  });
+
+  describe('logPermissionGrant', () => {
+    it('should log permission grant', () => {
+      const metadata: PermissionMetadata = { category: 'admin' };
+
+      const logSpy = jest.spyOn(service['logger'], 'log');
+
+      service.logPermissionGrant(mockInteraction, metadata);
+
+      expect(logSpy).toHaveBeenCalledWith('Permission granted', {
+        userId: '123456789012345678',
+        guildId: '987654321098765432',
+        commandName: 'test-command',
+        category: 'admin',
+      });
+    });
+
+    it('should use default category when metadata category is not provided', () => {
+      const logSpy = jest.spyOn(service['logger'], 'log');
+
+      service.logPermissionGrant(mockInteraction);
+
+      expect(logSpy).toHaveBeenCalledWith('Permission granted', {
+        userId: '123456789012345678',
+        guildId: '987654321098765432',
+        commandName: 'test-command',
+        category: 'public',
+      });
+    });
+
+    it('should handle DM interactions', () => {
+      const dmInteraction = {
+        ...mockInteraction,
+        guildId: null,
+      } as unknown as ChatInputCommandInteraction;
+
+      const logSpy = jest.spyOn(service['logger'], 'log');
+
+      service.logPermissionGrant(dmInteraction);
+
+      expect(logSpy).toHaveBeenCalledWith('Permission granted', {
+        userId: '123456789012345678',
+        guildId: 'DM',
+        commandName: 'test-command',
+        category: 'public',
+      });
+    });
+  });
+});

--- a/src/permissions/permission-logger/permission-logger.service.ts
+++ b/src/permissions/permission-logger/permission-logger.service.ts
@@ -1,0 +1,78 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ChatInputCommandInteraction } from 'discord.js';
+import { ValidationResult } from '../permission-validator/permission-validator.service';
+import { PermissionMetadata } from '../permission-metadata.interface';
+
+/**
+ * PermissionLoggerService - Single Responsibility: Log permission-related events
+ *
+ * Separation of Concerns: Logging logic separate from validation and execution.
+ * Centralizes all permission-related logging.
+ */
+@Injectable()
+export class PermissionLoggerService {
+  private readonly logger = new Logger(PermissionLoggerService.name);
+
+  /**
+   * Log command execution with permissions
+   * Single Responsibility: Logging execution events
+   */
+  logCommandExecution(
+    interaction: ChatInputCommandInteraction,
+    result: ValidationResult,
+    metadata?: PermissionMetadata,
+  ): void {
+    const guildId = interaction.guildId || 'DM';
+    const channelId = interaction.channelId || 'unknown';
+    const userId = interaction.user.id;
+    const commandName = interaction.commandName;
+
+    this.logger.log(`Command execution: ${commandName}`, {
+      userId,
+      guildId,
+      channelId,
+      allowed: result.allowed,
+      category: metadata?.category || 'public',
+    });
+  }
+
+  /**
+   * Log permission denial
+   * Single Responsibility: Logging denial events
+   */
+  logPermissionDenial(
+    interaction: ChatInputCommandInteraction,
+    reason: string,
+  ): void {
+    const guildId = interaction.guildId || 'DM';
+    const userId = interaction.user.id;
+    const commandName = interaction.commandName;
+
+    this.logger.warn('Permission denied', {
+      userId,
+      guildId,
+      commandName,
+      reason,
+    });
+  }
+
+  /**
+   * Log successful permission grant
+   * Single Responsibility: Logging grant events
+   */
+  logPermissionGrant(
+    interaction: ChatInputCommandInteraction,
+    metadata?: PermissionMetadata,
+  ): void {
+    const guildId = interaction.guildId || 'DM';
+    const userId = interaction.user.id;
+    const commandName = interaction.commandName;
+
+    this.logger.log('Permission granted', {
+      userId,
+      guildId,
+      commandName,
+      category: metadata?.category || 'public',
+    });
+  }
+}

--- a/src/permissions/permission-metadata.interface.ts
+++ b/src/permissions/permission-metadata.interface.ts
@@ -1,0 +1,35 @@
+import { PermissionResolvable } from 'discord.js';
+
+/**
+ * PermissionMetadata - Single Responsibility: Define permission requirements for commands
+ *
+ * Declarative interface for command permission requirements.
+ * Separates permission concerns from command execution logic.
+ */
+export interface PermissionMetadata {
+  /**
+   * Discord permission flags required to execute this command
+   * Set via setDefaultMemberPermissions on SlashCommandBuilder
+   */
+  requiredPermissions?: PermissionResolvable;
+
+  /**
+   * Whether this command requires guild context (not available in DMs)
+   */
+  requiresGuild?: boolean;
+
+  /**
+   * Whether this command requires super user permission
+   */
+  requiresSuperUser?: boolean;
+
+  /**
+   * Whether this command requires staff role from API settings
+   */
+  requiresStaffRole?: boolean;
+
+  /**
+   * Command category for organization and filtering
+   */
+  category?: 'admin' | 'user' | 'public';
+}

--- a/src/permissions/permission-validator/permission-validator.service.spec.ts
+++ b/src/permissions/permission-validator/permission-validator.service.spec.ts
@@ -1,0 +1,291 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PermissionValidatorService } from './permission-validator.service';
+import { ApiService } from '../../api/api.service';
+import { ConfigService } from '../../config/config.service';
+import {
+  ChatInputCommandInteraction,
+  GuildMember,
+  PermissionFlagsBits,
+} from 'discord.js';
+import { PermissionMetadata } from '../permission-metadata.interface';
+
+describe('PermissionValidatorService', () => {
+  let service: PermissionValidatorService;
+  let apiService: jest.Mocked<ApiService>;
+  let configService: jest.Mocked<ConfigService>;
+  let module: TestingModule;
+
+  const mockInteraction = {
+    user: { id: '123456789012345678' },
+    guildId: '987654321098765432',
+    commandName: 'test-command',
+    inGuild: jest.fn().mockReturnValue(true),
+    member: {
+      id: '123456789012345678',
+      permissions: {
+        has: jest.fn(),
+      },
+      roles: {
+        cache: {
+          keys: jest.fn().mockReturnValue(['role1', 'role2']),
+        },
+      },
+    } as unknown as GuildMember,
+  } as unknown as ChatInputCommandInteraction;
+
+  beforeEach(async () => {
+    const mockApiService = {
+      getGuildSettings: jest.fn(),
+    };
+
+    const mockConfigService = {
+      getSuperUserId: jest.fn(),
+    };
+
+    module = await Test.createTestingModule({
+      providers: [
+        PermissionValidatorService,
+        {
+          provide: ApiService,
+          useValue: mockApiService,
+        },
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<PermissionValidatorService>(
+      PermissionValidatorService,
+    );
+    apiService = module.get(ApiService);
+    configService = module.get(ConfigService);
+
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('validateCommandPermissions', () => {
+    it('should allow access when no metadata provided', async () => {
+      const result = await service.validateCommandPermissions(mockInteraction);
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should deny access when requiresGuild is true and not in guild', async () => {
+      const metadata: PermissionMetadata = { requiresGuild: true };
+      const dmInteraction = {
+        ...mockInteraction,
+        inGuild: jest.fn().mockReturnValue(false),
+      } as unknown as ChatInputCommandInteraction;
+
+      const result = await service.validateCommandPermissions(
+        dmInteraction,
+        metadata,
+      );
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('This command can only be used in servers');
+    });
+
+    it('should allow access in DM when no guild requirement', async () => {
+      const metadata: PermissionMetadata = {
+        requiredPermissions: PermissionFlagsBits.Administrator,
+      };
+      const dmInteraction = {
+        ...mockInteraction,
+        inGuild: jest.fn().mockReturnValue(false),
+        member: null,
+      } as unknown as ChatInputCommandInteraction;
+
+      const result = await service.validateCommandPermissions(
+        dmInteraction,
+        metadata,
+      );
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should deny access when requiresSuperUser is true and user is not super user', async () => {
+      const metadata: PermissionMetadata = { requiresSuperUser: true };
+      configService.getSuperUserId.mockReturnValue('999999999999999999');
+
+      const result = await service.validateCommandPermissions(
+        mockInteraction,
+        metadata,
+      );
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe(
+        'You do not have permission to use this command.',
+      );
+    });
+
+    it('should allow access when requiresSuperUser is true and user is super user', async () => {
+      const metadata: PermissionMetadata = { requiresSuperUser: true };
+      configService.getSuperUserId.mockReturnValue('123456789012345678');
+
+      const result = await service.validateCommandPermissions(
+        mockInteraction,
+        metadata,
+      );
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should deny access when super user ID is not configured', async () => {
+      const metadata: PermissionMetadata = { requiresSuperUser: true };
+      configService.getSuperUserId.mockReturnValue(undefined);
+
+      const result = await service.validateCommandPermissions(
+        mockInteraction,
+        metadata,
+      );
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should allow access when member has Administrator permission', async () => {
+      const metadata: PermissionMetadata = {
+        requiredPermissions: PermissionFlagsBits.Administrator,
+      };
+      const member = mockInteraction.member as GuildMember;
+      jest
+        .spyOn(member.permissions, 'has')
+        .mockImplementation()
+        .mockReturnValue(true);
+
+      const result = await service.validateCommandPermissions(
+        mockInteraction,
+        metadata,
+      );
+      expect(result.allowed).toBe(true);
+      expect(member.permissions.has).toHaveBeenCalledWith(
+        PermissionFlagsBits.Administrator,
+      );
+    });
+
+    it('should deny access when member does not have required permissions', async () => {
+      const metadata: PermissionMetadata = {
+        requiredPermissions: PermissionFlagsBits.ManageChannels,
+      };
+      const member = mockInteraction.member as GuildMember;
+      jest
+        .spyOn(member.permissions, 'has')
+        .mockImplementation()
+        .mockReturnValue(false);
+
+      const result = await service.validateCommandPermissions(
+        mockInteraction,
+        metadata,
+      );
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe(
+        'You do not have permission to use this command',
+      );
+    });
+
+    it('should allow access when requiresStaffRole is true and user has staff role', async () => {
+      const metadata: PermissionMetadata = { requiresStaffRole: true };
+      apiService.getGuildSettings.mockResolvedValue({
+        staffRoles: ['role1', 'role3'],
+      });
+
+      const result = await service.validateCommandPermissions(
+        mockInteraction,
+        metadata,
+      );
+      expect(result.allowed).toBe(true);
+      expect(apiService.getGuildSettings).toHaveBeenCalledWith(
+        '987654321098765432',
+      );
+    });
+
+    it('should deny access when requiresStaffRole is true and user does not have staff role', async () => {
+      const metadata: PermissionMetadata = { requiresStaffRole: true };
+      apiService.getGuildSettings.mockResolvedValue({
+        staffRoles: ['role3', 'role4'],
+      });
+
+      const result = await service.validateCommandPermissions(
+        mockInteraction,
+        metadata,
+      );
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe(
+        'You do not have permission to use this command',
+      );
+    });
+
+    it('should deny access when requiresStaffRole is true and no staff roles configured', async () => {
+      const metadata: PermissionMetadata = { requiresStaffRole: true };
+      apiService.getGuildSettings.mockResolvedValue({
+        staffRoles: [],
+      });
+
+      const result = await service.validateCommandPermissions(
+        mockInteraction,
+        metadata,
+      );
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should allow access when requiresStaffRole is true but staffRoles is undefined', async () => {
+      const metadata: PermissionMetadata = { requiresStaffRole: true };
+      apiService.getGuildSettings.mockResolvedValue({});
+
+      const result = await service.validateCommandPermissions(
+        mockInteraction,
+        metadata,
+      );
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should allow access when API error occurs and fails open', async () => {
+      const metadata: PermissionMetadata = { requiresStaffRole: true };
+      apiService.getGuildSettings.mockRejectedValue(new Error('API error'));
+
+      const result = await service.validateCommandPermissions(
+        mockInteraction,
+        metadata,
+      );
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should handle permission check error gracefully', async () => {
+      const metadata: PermissionMetadata = {
+        requiredPermissions: PermissionFlagsBits.ManageChannels,
+      };
+      const member = mockInteraction.member as GuildMember;
+      jest.spyOn(member.permissions, 'has').mockImplementation(() => {
+        throw new Error('Permission check error');
+      });
+
+      const result = await service.validateCommandPermissions(
+        mockInteraction,
+        metadata,
+      );
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should allow access when all checks pass', async () => {
+      const metadata: PermissionMetadata = {
+        requiredPermissions: PermissionFlagsBits.Administrator,
+        requiresGuild: true,
+      };
+      const member = mockInteraction.member as GuildMember;
+      jest
+        .spyOn(member.permissions, 'has')
+        .mockImplementation()
+        .mockReturnValue(true);
+
+      const result = await service.validateCommandPermissions(
+        mockInteraction,
+        metadata,
+      );
+      expect(result.allowed).toBe(true);
+    });
+  });
+});

--- a/src/permissions/permission-validator/permission-validator.service.ts
+++ b/src/permissions/permission-validator/permission-validator.service.ts
@@ -1,0 +1,184 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  ChatInputCommandInteraction,
+  PermissionFlagsBits,
+  PermissionResolvable,
+  GuildMember,
+} from 'discord.js';
+import { ApiService } from '../../api/api.service';
+import { ConfigService } from '../../config/config.service';
+import { PermissionMetadata } from '../permission-metadata.interface';
+
+/**
+ * ValidationResult - Result of permission validation
+ */
+export interface ValidationResult {
+  allowed: boolean;
+  reason?: string;
+}
+
+/**
+ * PermissionValidatorService - Single Responsibility: Validate command permissions
+ *
+ * Separates permission validation logic from logging and execution.
+ * Only validates permissions, doesn't log or execute commands.
+ */
+@Injectable()
+export class PermissionValidatorService {
+  private readonly logger = new Logger(PermissionValidatorService.name);
+
+  constructor(
+    private readonly apiService: ApiService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  /**
+   * Validate if user has permission to execute command
+   * Single Responsibility: Permission validation only
+   */
+  async validateCommandPermissions(
+    interaction: ChatInputCommandInteraction,
+    metadata?: PermissionMetadata,
+  ): Promise<ValidationResult> {
+    // If no metadata, allow access (public command)
+    if (!metadata) {
+      return { allowed: true };
+    }
+
+    // Check if command requires guild context
+    if (metadata.requiresGuild && !interaction.inGuild()) {
+      return {
+        allowed: false,
+        reason: 'This command can only be used in servers',
+      };
+    }
+
+    // Check if interaction has member (guild context)
+    if (!interaction.member) {
+      return { allowed: true }; // DMs don't need permission checks beyond guild requirement
+    }
+
+    const member = interaction.member as GuildMember;
+    const userId = interaction.user.id;
+    const guildId = interaction.guildId;
+
+    // Check super user if required
+    if (metadata.requiresSuperUser) {
+      const superUserId = this.configService.getSuperUserId();
+      if (!superUserId || userId !== superUserId) {
+        this.logger.warn(
+          `Unauthorized super user attempt by user ${userId} on command ${interaction.commandName}`,
+        );
+        return {
+          allowed: false,
+          reason: 'You do not have permission to use this command.',
+        };
+      }
+    }
+
+    // Check Discord permissions if specified
+    if (metadata.requiredPermissions) {
+      const hasPermission = this.checkDiscordPermissions(
+        member,
+        metadata.requiredPermissions,
+      );
+
+      if (!hasPermission) {
+        return {
+          allowed: false,
+          reason: 'You do not have permission to use this command',
+        };
+      }
+    }
+
+    // Check staff roles if required
+    if (metadata.requiresStaffRole && guildId) {
+      try {
+        const hasStaffRole = await this.checkStaffRoles(member, guildId);
+        if (!hasStaffRole) {
+          return {
+            allowed: false,
+            reason: 'You do not have permission to use this command',
+          };
+        }
+      } catch (error: unknown) {
+        const errorMessage =
+          error instanceof Error ? error.message : 'Unknown error';
+        this.logger.error(
+          `Error checking staff roles for user ${userId} in guild ${guildId}:`,
+          errorMessage,
+        );
+        // On error, allow access but log it (fail open for now)
+        // In production, you might want to fail closed
+        return { allowed: true };
+      }
+    }
+
+    return { allowed: true };
+  }
+
+  /**
+   * Check if member has Discord permissions
+   * Private: Single Responsibility - internal validation helper
+   */
+  private checkDiscordPermissions(
+    member: GuildMember,
+    permissions: PermissionResolvable,
+  ): boolean {
+    try {
+      // If member is guild owner or administrator, allow all commands
+      if (member.permissions.has(PermissionFlagsBits.Administrator)) {
+        return true;
+      }
+
+      // Check specific permissions
+      return member.permissions.has(permissions);
+    } catch (error: unknown) {
+      this.logger.error('Error checking Discord permissions:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Check if member has staff role from API settings
+   * Private: Single Responsibility - check staff roles from API
+   */
+  private async checkStaffRoles(
+    member: GuildMember,
+    guildId: string,
+  ): Promise<boolean> {
+    try {
+      const settings: unknown = await this.apiService.getGuildSettings(guildId);
+      let staffRoles: string[] | undefined;
+      if (
+        settings &&
+        typeof settings === 'object' &&
+        'staffRoles' in settings
+      ) {
+        const rolesValue = (settings as { staffRoles?: unknown }).staffRoles;
+        if (Array.isArray(rolesValue)) {
+          staffRoles = rolesValue as string[];
+        }
+      }
+
+      if (!staffRoles || staffRoles.length === 0) {
+        // No staff roles configured, deny access
+        return false;
+      }
+
+      // Check if member has any of the staff roles
+      const memberRoles = Array.from(member.roles.cache.keys());
+      return staffRoles.some((staffRoleId) =>
+        memberRoles.includes(staffRoleId),
+      );
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(
+        `Error fetching staff roles for guild ${guildId}:`,
+        errorMessage,
+      );
+      throw error;
+    }
+  }
+}

--- a/src/permissions/permission/permission.guard.spec.ts
+++ b/src/permissions/permission/permission.guard.spec.ts
@@ -1,0 +1,267 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { PermissionGuard } from './permission.guard';
+import { PermissionValidatorService } from '../permission-validator/permission-validator.service';
+import { PermissionLoggerService } from '../permission-logger/permission-logger.service';
+import { ChatInputCommandInteraction } from 'discord.js';
+import { ValidationResult } from '../permission-validator/permission-validator.service';
+
+describe('PermissionGuard', () => {
+  let guard: PermissionGuard;
+  let validatorService: jest.Mocked<PermissionValidatorService>;
+  let loggerService: jest.Mocked<PermissionLoggerService>;
+  let mockExecutionContext: ExecutionContext;
+  let module: TestingModule;
+
+  const mockInteraction = {
+    user: { id: '123456789012345678' },
+    guildId: '987654321098765432',
+    commandName: 'test-command',
+    replied: false,
+    deferred: false,
+    reply: jest.fn().mockResolvedValue(undefined),
+    followUp: jest.fn().mockResolvedValue(undefined),
+  } as unknown as ChatInputCommandInteraction;
+
+  beforeEach(async () => {
+    const mockValidatorService = {
+      validateCommandPermissions: jest.fn(),
+    };
+
+    const mockLoggerService = {
+      logCommandExecution: jest.fn(),
+      logPermissionDenial: jest.fn(),
+      logPermissionGrant: jest.fn(),
+    };
+
+    module = await Test.createTestingModule({
+      providers: [
+        PermissionGuard,
+        {
+          provide: PermissionValidatorService,
+          useValue: mockValidatorService,
+        },
+        {
+          provide: PermissionLoggerService,
+          useValue: mockLoggerService,
+        },
+      ],
+    }).compile();
+
+    guard = module.get<PermissionGuard>(PermissionGuard);
+    validatorService = module.get(PermissionValidatorService);
+    loggerService = module.get(PermissionLoggerService);
+
+    mockExecutionContext = {
+      getArgs: jest.fn().mockReturnValue([mockInteraction]),
+      switchToHttp: jest.fn(),
+      getClass: jest.fn(),
+      getHandler: jest.fn(),
+      getArgByIndex: jest.fn(),
+      switchToRpc: jest.fn(),
+      switchToWs: jest.fn(),
+      getType: jest.fn(),
+    } as unknown as ExecutionContext;
+
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  describe('canActivate', () => {
+    it('should return true when no Discord interaction', async () => {
+      const nonDiscordContext = {
+        ...mockExecutionContext,
+        getArgs: jest.fn().mockReturnValue([{ type: 'not-discord' }]),
+      } as unknown as ExecutionContext;
+
+      const result = await guard.canActivate(nonDiscordContext);
+      expect(result).toBe(true);
+      expect(
+        validatorService.validateCommandPermissions,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should return true when permission is granted', async () => {
+      const result: ValidationResult = { allowed: true };
+      validatorService.validateCommandPermissions.mockResolvedValue(result);
+
+      const canActivate = await guard.canActivate(mockExecutionContext);
+
+      expect(canActivate).toBe(true);
+      expect(validatorService.validateCommandPermissions).toHaveBeenCalled();
+      expect(loggerService.logCommandExecution).toHaveBeenCalled();
+      expect(loggerService.logPermissionGrant).toHaveBeenCalled();
+      expect(mockInteraction.reply).not.toHaveBeenCalled();
+    });
+
+    it('should throw ForbiddenException when permission is denied', async () => {
+      const result: ValidationResult = {
+        allowed: false,
+        reason: 'You do not have permission',
+      };
+      validatorService.validateCommandPermissions.mockResolvedValue(result);
+
+      await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
+        ForbiddenException,
+      );
+
+      expect(validatorService.validateCommandPermissions).toHaveBeenCalled();
+      expect(loggerService.logCommandExecution).toHaveBeenCalled();
+      expect(loggerService.logPermissionDenial).toHaveBeenCalledWith(
+        mockInteraction,
+        'You do not have permission',
+      );
+      expect(mockInteraction.reply).toHaveBeenCalledWith({
+        content: 'You do not have permission',
+        ephemeral: true,
+      });
+    });
+
+    it('should send denial message via reply when not replied or deferred', async () => {
+      const result: ValidationResult = {
+        allowed: false,
+        reason: 'Permission denied',
+      };
+      validatorService.validateCommandPermissions.mockResolvedValue(result);
+
+      await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
+        ForbiddenException,
+      );
+
+      expect(mockInteraction.reply).toHaveBeenCalledWith({
+        content: 'Permission denied',
+        ephemeral: true,
+      });
+      expect(mockInteraction.followUp).not.toHaveBeenCalled();
+    });
+
+    it('should send denial message via followUp when already replied', async () => {
+      const repliedInteraction = {
+        ...mockInteraction,
+        replied: true,
+      } as unknown as ChatInputCommandInteraction;
+
+      const repliedContext = {
+        ...mockExecutionContext,
+        getArgs: jest.fn().mockReturnValue([repliedInteraction]),
+      } as unknown as ExecutionContext;
+
+      const result: ValidationResult = {
+        allowed: false,
+        reason: 'Permission denied',
+      };
+      validatorService.validateCommandPermissions.mockResolvedValue(result);
+
+      await expect(guard.canActivate(repliedContext)).rejects.toThrow(
+        ForbiddenException,
+      );
+
+      expect(repliedInteraction.followUp).toHaveBeenCalledWith({
+        content: 'Permission denied',
+        ephemeral: true,
+      });
+      expect(repliedInteraction.reply).not.toHaveBeenCalled();
+    });
+
+    it('should use default reason when reason is not provided', async () => {
+      const result: ValidationResult = {
+        allowed: false,
+      };
+      validatorService.validateCommandPermissions.mockResolvedValue(result);
+
+      await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
+        ForbiddenException,
+      );
+
+      expect(loggerService.logPermissionDenial).toHaveBeenCalledWith(
+        mockInteraction,
+        'Access denied',
+      );
+      expect(mockInteraction.reply).toHaveBeenCalledWith({
+        content: '❌ You do not have permission to use this command.',
+        ephemeral: true,
+      });
+    });
+
+    it('should handle error in validator service gracefully', async () => {
+      const error = new Error('Validation error');
+      validatorService.validateCommandPermissions.mockRejectedValue(error);
+
+      await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
+        ForbiddenException,
+      );
+
+      expect(mockInteraction.reply).toHaveBeenCalledWith({
+        content:
+          'An error occurred while checking permissions. Please try again later.',
+        ephemeral: true,
+      });
+    });
+
+    it('should re-throw ForbiddenException if already thrown', async () => {
+      const forbiddenError = new ForbiddenException('Permission denied');
+      validatorService.validateCommandPermissions.mockRejectedValue(
+        forbiddenError,
+      );
+
+      await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
+        ForbiddenException,
+      );
+
+      expect(mockInteraction.reply).not.toHaveBeenCalled();
+    });
+
+    it('should handle error sending denial message gracefully', async () => {
+      const result: ValidationResult = {
+        allowed: false,
+        reason: 'Permission denied',
+      };
+      validatorService.validateCommandPermissions.mockResolvedValue(result);
+      const errorInteraction = {
+        ...mockInteraction,
+        reply: jest.fn().mockRejectedValue(new Error('Send failed')),
+      } as unknown as ChatInputCommandInteraction;
+
+      const errorContext = {
+        ...mockExecutionContext,
+        getArgs: jest.fn().mockReturnValue([errorInteraction]),
+      } as unknown as ExecutionContext;
+
+      await expect(guard.canActivate(errorContext)).rejects.toThrow(
+        ForbiddenException,
+      );
+
+      // Should not throw even if reply fails
+      expect(errorInteraction.reply).toHaveBeenCalled();
+    });
+
+    it('should get metadata for command from mapping', async () => {
+      const processTrackersInteraction = {
+        ...mockInteraction,
+        commandName: 'process-trackers',
+      } as unknown as ChatInputCommandInteraction;
+
+      const processTrackersContext = {
+        ...mockExecutionContext,
+        getArgs: jest.fn().mockReturnValue([processTrackersInteraction]),
+      } as unknown as ExecutionContext;
+
+      const result: ValidationResult = { allowed: true };
+      validatorService.validateCommandPermissions.mockResolvedValue(result);
+
+      await guard.canActivate(processTrackersContext);
+
+      expect(validatorService.validateCommandPermissions).toHaveBeenCalledWith(
+        processTrackersInteraction,
+        { requiresSuperUser: true, requiresGuild: true },
+      );
+    });
+  });
+});

--- a/src/permissions/permission/permission.guard.ts
+++ b/src/permissions/permission/permission.guard.ts
@@ -1,0 +1,150 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  ForbiddenException,
+} from '@nestjs/common';
+import { ChatInputCommandInteraction } from 'discord.js';
+import { PermissionValidatorService } from '../permission-validator/permission-validator.service';
+import { PermissionLoggerService } from '../permission-logger/permission-logger.service';
+import { PermissionMetadata } from '../permission-metadata.interface';
+
+/**
+ * PermissionGuard - Guard that validates permissions before command execution
+ * Throws ForbiddenException if permission is denied
+ */
+@Injectable()
+export class PermissionGuard implements CanActivate {
+  private readonly logger = new Logger(PermissionGuard.name);
+
+  // Command metadata mapping - maps command names to permission requirements
+  private readonly commandMetadata: Map<string, PermissionMetadata> = new Map([
+    ['process-trackers', { requiresSuperUser: true, requiresGuild: true }],
+    [
+      'config',
+      {
+        requiredPermissions: 'Administrator' as const,
+        requiresGuild: true,
+        category: 'admin',
+      },
+    ],
+    // Add more commands as needed
+  ]);
+
+  constructor(
+    private readonly permissionValidator: PermissionValidatorService,
+    private readonly permissionLogger: PermissionLoggerService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const interaction = this.getInteraction(context);
+    if (!interaction) {
+      // Not a Discord interaction, allow access
+      return true;
+    }
+
+    const commandName = interaction.commandName;
+    const metadata = this.getMetadata(commandName);
+
+    try {
+      const result = await this.permissionValidator.validateCommandPermissions(
+        interaction,
+        metadata,
+      );
+
+      this.permissionLogger.logCommandExecution(interaction, result, metadata);
+
+      if (!result.allowed) {
+        this.permissionLogger.logPermissionDenial(
+          interaction,
+          result.reason || 'Access denied',
+        );
+        await this.sendDenialMessage(interaction, result.reason);
+        throw new ForbiddenException(result.reason || 'Permission denied');
+      }
+
+      this.permissionLogger.logPermissionGrant(interaction, metadata);
+      return true;
+    } catch (error: unknown) {
+      // If it's already a ForbiddenException, re-throw it
+      if (error instanceof ForbiddenException) {
+        throw error;
+      }
+
+      // Log unexpected errors and deny access
+      this.logger.error('Error in permission guard:', error);
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      await this.sendDenialMessage(
+        interaction,
+        'An error occurred while checking permissions. Please try again later.',
+      );
+      throw new ForbiddenException(`Permission check failed: ${errorMessage}`);
+    }
+  }
+
+  /**
+   * Extract ChatInputCommandInteraction from ExecutionContext
+   * Similar to CooldownInterceptor.getInteraction()
+   */
+  private getInteraction(
+    context: ExecutionContext,
+  ): ChatInputCommandInteraction | null {
+    const args = context.getArgs();
+    if (args && args.length > 0) {
+      const firstArg = args[0] as unknown;
+      if (
+        firstArg &&
+        typeof firstArg === 'object' &&
+        'commandName' in firstArg &&
+        'user' in firstArg
+      ) {
+        return firstArg as ChatInputCommandInteraction;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Get permission metadata for a command
+   * Can be extended to use Reflector if Necord supports SetMetadata decorator
+   */
+  private getMetadata(commandName: string): PermissionMetadata | undefined {
+    return this.commandMetadata.get(commandName);
+  }
+
+  /**
+   * Send denial message to Discord interaction
+   * Single Responsibility: Send error message to user
+   */
+  private async sendDenialMessage(
+    interaction: ChatInputCommandInteraction,
+    reason?: string,
+  ): Promise<void> {
+    try {
+      const message =
+        reason || '❌ You do not have permission to use this command.';
+
+      if (interaction.replied || interaction.deferred) {
+        await interaction.followUp({
+          content: message,
+          ephemeral: true,
+        });
+      } else {
+        await interaction.reply({
+          content: message,
+          ephemeral: true,
+        });
+      }
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(
+        `Failed to send denial message to user ${interaction.user.id}:`,
+        errorMessage,
+      );
+      // Don't throw - we've already thrown ForbiddenException
+    }
+  }
+}

--- a/src/permissions/permissions.module.ts
+++ b/src/permissions/permissions.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { ApiModule } from '../api/api.module';
+import { ConfigModule } from '../config/config.module';
+import { PermissionValidatorService } from './permission-validator/permission-validator.service';
+import { PermissionLoggerService } from './permission-logger/permission-logger.service';
+import { PermissionGuard } from './permission/permission.guard';
+
+@Module({
+  imports: [ApiModule, ConfigModule],
+  providers: [
+    PermissionValidatorService,
+    PermissionLoggerService,
+    PermissionGuard,
+  ],
+  exports: [
+    PermissionGuard,
+    PermissionValidatorService,
+    PermissionLoggerService,
+  ],
+})
+export class PermissionsModule {}


### PR DESCRIPTION
## Description
Migrate permission validation and logging to NestJS guards and services.

## Tasks Completed
- [x] **Generate Permissions module using NestJS structure**
- [x] Migrate PermissionValidatorService to NestJS @Injectable
- [x] Migrate PermissionLoggerService to NestJS @Injectable
- [x] Replace permission middleware with NestJS guards
- [x] Integrate permission checks with command guards
- [x] Ensure Discord permission checks still work (Administrator, etc.)
- [x] Support custom staff roles from API settings
- [x] Remove old permission middleware

## Permission Checks Implemented
- Discord permissions (Administrator flag)
- Custom staff roles from API
- Guild context requirements
- Super user checks

## Acceptance Criteria
- [x] All permission checks work as before
- [x] Permission logging still functions
- [x] Staff role checks from API work
- [x] Clear error messages for permission denials
- [x] Proper integration with Necord commands

## Changes
- Added `src/permissions/` module with services and guards
- Integrated PermissionGuard globally in CommandsModule
- Added comprehensive test coverage
- Updated command files to remove inline permission checks

Closes #15